### PR TITLE
SM-2982 : Create OSGi bundles for Spring Security 4.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,12 @@
     <name>Apache ServiceMix :: Bundles</name>
 
     <modules>
-        <!-- add modules for all bundles to released in the next batch here -->
+        <!-- add modules for all bundles to released in the next batch here -->        
+        <module>spring-security-acl-4.1.0.RELEASE</module>
+        <module>spring-security-config-4.1.0.RELEASE</module>
+        <module>spring-security-core-4.1.0.RELEASE</module>
+        <module>spring-security-taglibs-4.1.0.RELEASE</module>
+        <module>spring-security-web-4.1.0.RELEASE</module>
     </modules>
 
 </project>

--- a/spring-security-acl-4.1.0.RELEASE/pom.xml
+++ b/spring-security-acl-4.1.0.RELEASE/pom.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <!--
+
+        Licensed to the Apache Software Foundation (ASF) under one or more
+        contributor license agreements.  See the NOTICE file distributed with
+        this work for additional information regarding copyright ownership.
+        The ASF licenses this file to You under the Apache License, Version 2.0
+        (the "License"); you may not use this file except in compliance with
+        the License.  You may obtain a copy of the License at
+
+           http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+    -->
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.servicemix.bundles</groupId>
+        <artifactId>bundles-pom</artifactId>
+        <version>12</version>
+        <relativePath>../bundles-pom/pom.xml</relativePath>
+    </parent>
+
+    <groupId>org.apache.servicemix.bundles</groupId>
+    <artifactId>org.apache.servicemix.bundles.spring-security-acl</artifactId>
+    <version>4.1.0.RELEASE_1-SNAPSHOT</version>
+    <packaging>bundle</packaging>
+    <name>Apache ServiceMix :: Bundles :: ${pkgArtifactId}</name>
+
+    <scm>
+        <connection>scm:git:https://git-wip-us.apache.org/repos/asf/servicemix-bundles.git</connection>
+        <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/servicemix-bundles.git</developerConnection>
+        <url>https://git-wip-us.apache.org/repos/asf?p=servicemix-bundles.git</url>
+      <tag>HEAD</tag>
+  </scm>
+
+    <properties>
+        <pkgGroupId>org.springframework.security</pkgGroupId>
+        <pkgArtifactId>spring-security-acl</pkgArtifactId>
+        <pkgVersion>4.1.0.RELEASE</pkgVersion>
+        <servicemix.osgi.export.pkg>
+            org.springframework.security.acl
+        </servicemix.osgi.export.pkg>
+        <servicemix.osgi.import.pkg>
+            javax.sql;resolution:=optional;version=0,
+            net.sf.ehcache;resolution:=optional;version="[1.4.1,2.5.0)",
+            org.aopalliance.intercept;version="[1.0.0, 2.0.0)",
+            org.apache.commons.logging;version="[1.0.4, 2.0.0)",
+            org.springframework.cache;resolution:=optional;version="[4,5)",
+            org.springframework.context;resolution:=optional;version="[4,5)",
+            org.springframework.context.support;resolution:=optional;version="[4,5)",
+            org.springframework.dao;resolution:=optional;version="[4,5)",
+            org.springframework.jdbc.core;resolution:=optional;version="[4,5)",
+            org.springframework.security.access;version="[4.1,5)",
+            org.springframework.security.access.hierarchicalroles;version="[4.1,5)",
+            org.springframework.security.access.vote;version="[4.1,5)",
+            org.springframework.security.core;version="[4.1,5)",
+            org.springframework.security.core.context;version="[4.1,5)",
+            org.springframework.security.core.userdetails;version="[4.1,5)",
+            org.springframework.security.util;version="[4.1,5)",
+            org.springframework.transaction.support;resolution:=optional;version="[4.1,5)",
+            org.springframework.util;resolution:=optional;version="[4.1,5)"
+        </servicemix.osgi.import.pkg>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${pkgGroupId}</groupId>
+            <artifactId>${pkgArtifactId}</artifactId>
+            <version>${pkgVersion}</version>
+        </dependency>
+
+        <!-- sources -->
+        <dependency>
+            <groupId>${pkgGroupId}</groupId>
+            <artifactId>${pkgArtifactId}</artifactId>
+            <version>${pkgVersion}</version>
+            <classifier>sources</classifier>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>${pkgGroupId}:${pkgArtifactId}</include>
+                                </includes>
+                            </artifactSet>
+                            <filters>
+                                <filter>
+                                    <artifact>${pkgGroupId}:${pkgArtifactId}</artifact>
+                                    <excludes>
+                                        <exclude>**</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+                            <createDependencyReducedPom>true</createDependencyReducedPom>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/spring-security-acl-4.1.0.RELEASE/src/main/resources/OSGI-INF/bundle.info
+++ b/spring-security-acl-4.1.0.RELEASE/src/main/resources/OSGI-INF/bundle.info
@@ -1,0 +1,11 @@
+\u001B[1mSYNOPSIS\u001B[0m
+    ${project.description}
+
+    Original Maven URL:
+        \u001B[33mmvn:${pkgGroupId}/${pkgArtifactId}/${pkgVersion}\u001B[0m
+
+\u001B[1mDESCRIPTION\u001B[0m
+    Spring Framework Security Acl module.
+
+\u001B[1mSEE ALSO\u001B[0m
+    \u001B[36mhttp://www.springsource.org/spring-framework\u001B[0m

--- a/spring-security-config-4.1.0.RELEASE/pom.xml
+++ b/spring-security-config-4.1.0.RELEASE/pom.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <!--
+
+        Licensed to the Apache Software Foundation (ASF) under one or more
+        contributor license agreements.  See the NOTICE file distributed with
+        this work for additional information regarding copyright ownership.
+        The ASF licenses this file to You under the Apache License, Version 2.0
+        (the "License"); you may not use this file except in compliance with
+        the License.  You may obtain a copy of the License at
+
+           http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+    -->
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.servicemix.bundles</groupId>
+        <artifactId>bundles-pom</artifactId>
+        <version>12</version>
+        <relativePath>../bundles-pom/pom.xml</relativePath>
+    </parent>
+
+    <groupId>org.apache.servicemix.bundles</groupId>
+    <artifactId>org.apache.servicemix.bundles.spring-security-config</artifactId>
+    <version>4.1.0.RELEASE_1-SNAPSHOT</version>
+    <packaging>bundle</packaging>
+    <name>Apache ServiceMix :: Bundles :: ${pkgArtifactId}</name>
+
+    <scm>
+        <connection>scm:git:https://git-wip-us.apache.org/repos/asf/servicemix-bundles.git</connection>
+        <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/servicemix-bundles.git</developerConnection>
+        <url>https://git-wip-us.apache.org/repos/asf?p=servicemix-bundles.git</url>
+      <tag>HEAD</tag>
+  </scm>
+
+    <properties>
+        <pkgGroupId>org.springframework.security</pkgGroupId>
+        <pkgArtifactId>spring-security-config</pkgArtifactId>
+        <pkgVersion>4.1.0.RELEASE</pkgVersion>
+        <servicemix.osgi.export.pkg>
+            org.springframework.security.config
+        </servicemix.osgi.export.pkg>
+        <servicemix.osgi.import.pkg>
+            javax.servlet;resolution:=optional;version=0,
+            javax.servlet.http;resolution:=optional;version=0,
+            org.apache.commons.logging;version="[1.0.4,2.0.0)",
+            org.aspectj.weaver.tools;resolution:=optional;version="[1.7,2)",
+            org.springframework.aop*;resolution:=optional;version="[4,5)",
+            org.springframework.beans*;version="[4,5)",
+            org.springframework.context*;version="[4,5)",
+            org.springframework.core*;version="[4,5)",
+            org.springframework.security.web*;resolution:=optional;version="[4.1,5)",
+            org.springframework.security.ldap*;resolution:=optional;version="[4.1,5)",
+            org.springframework.security.messaging*;resolution:=optional;version="[4.1,5)",
+            org.springframework.security.openid*;resolution:=optional;version="[4.1,5)",
+            org.springframework.security.crypto*;resolution:=optional;version="[4.1,5)",
+            org.springframework.security.crypto.password;version="[4.1,5)",
+            org.springframework.security.crypto.bcrypt;version="[4.1,5)",
+            org.springframework.security*;version="[4.1,5)",
+            org.springframework.web*;resolution:=optional;version="[4,5)",
+            org.springframework.util;version="[4,5)",
+            org.springframework.util.xml;version="[4,5)",
+            org.w3c.dom;resolution:=optional;version=0,
+            javax.sql;resolution:=optional, 
+            org.aopalliance.intercept;resolution:=optional, 
+            org.openid4java.consumer;resolution:=optional, 
+            org.springframework.http;resolution:=optional;version="[4,5)", 
+            org.springframework.jdbc.datasource.init;resolution:=optional;version="[4,5)", 
+            org.springframework.ldap.core*;resolution:=optional;version="[4,5)",
+            org.springframework.messaging*;resolution:=optional;version="[4,5)"
+        </servicemix.osgi.import.pkg>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${pkgGroupId}</groupId>
+            <artifactId>${pkgArtifactId}</artifactId>
+            <version>${pkgVersion}</version>
+        </dependency>
+
+        <!-- sources -->
+        <dependency>
+            <groupId>${pkgGroupId}</groupId>
+            <artifactId>${pkgArtifactId}</artifactId>
+            <version>${pkgVersion}</version>
+            <classifier>sources</classifier>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>${pkgGroupId}:${pkgArtifactId}</include>
+                                </includes>
+                            </artifactSet>
+                            <filters>
+                                <filter>
+                                    <artifact>${pkgGroupId}:${pkgArtifactId}</artifact>
+                                    <excludes>
+                                        <exclude>**</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+                            <createDependencyReducedPom>true</createDependencyReducedPom>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/spring-security-config-4.1.0.RELEASE/src/main/resources/OSGI-INF/bundle.info
+++ b/spring-security-config-4.1.0.RELEASE/src/main/resources/OSGI-INF/bundle.info
@@ -1,0 +1,11 @@
+\u001B[1mSYNOPSIS\u001B[0m
+    ${project.description}
+
+    Original Maven URL:
+        \u001B[33mmvn:${pkgGroupId}/${pkgArtifactId}/${pkgVersion}\u001B[0m
+
+\u001B[1mDESCRIPTION\u001B[0m
+    Spring Framework Security Config module.
+
+\u001B[1mSEE ALSO\u001B[0m
+    \u001B[36mhttp://www.springsource.org/spring-framework\u001B[0m

--- a/spring-security-core-4.1.0.RELEASE/pom.xml
+++ b/spring-security-core-4.1.0.RELEASE/pom.xml
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <!--
+
+        Licensed to the Apache Software Foundation (ASF) under one or more
+        contributor license agreements.  See the NOTICE file distributed with
+        this work for additional information regarding copyright ownership.
+        The ASF licenses this file to You under the Apache License, Version 2.0
+        (the "License"); you may not use this file except in compliance with
+        the License.  You may obtain a copy of the License at
+
+           http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+    -->
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.servicemix.bundles</groupId>
+        <artifactId>bundles-pom</artifactId>
+        <version>12</version>
+        <relativePath>../bundles-pom/pom.xml</relativePath>
+    </parent>
+
+    <groupId>org.apache.servicemix.bundles</groupId>
+    <artifactId>org.apache.servicemix.bundles.spring-security-core</artifactId>
+    <version>4.1.0.RELEASE_1-SNAPSHOT</version>
+    <packaging>bundle</packaging>
+    <name>Apache ServiceMix :: Bundles :: ${pkgArtifactId}</name>
+
+    <scm>
+        <connection>scm:git:https://git-wip-us.apache.org/repos/asf/servicemix-bundles.git</connection>
+        <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/servicemix-bundles.git</developerConnection>
+        <url>https://git-wip-us.apache.org/repos/asf?p=servicemix-bundles.git</url>
+      <tag>HEAD</tag>
+  </scm>
+
+    <properties>
+        <pkgGroupId>org.springframework.security</pkgGroupId>
+        <pkgArtifactId>spring-security-core</pkgArtifactId>
+        <pkgVersion>4.1.0.RELEASE</pkgVersion>
+        <servicemix.osgi.export.pkg>
+            org.springframework.security
+        </servicemix.osgi.export.pkg>
+        <servicemix.osgi.import.pkg>
+            javax.annotation.security;resolution:=optional;version=0,
+            javax.crypto;resolution:=optional;version=0,
+            javax.crypto.spec;resolution:=optional;version=0,
+            javax.security.auth;resolution:=optional;version=0,
+            javax.security.auth.callback;resolution:=optional;version=0,
+            javax.security.auth.login;resolution:=optional;version=0,
+            javax.security.auth.spi;resolution:=optional;version=0,
+            net.sf.ehcache;resolution:=optional;version="[1.4.1,2.5.0)",
+            org.aopalliance.aop;version="[1.0.0,2.0.0)",
+            org.aopalliance.intercept;version="[1.0.0,2.0.0)",
+            org.apache.commons.logging;version="[1.0.4,2.0.0)",
+            org.aspectj.lang;resolution:=optional;version="[1.7,2)",
+            org.aspectj.lang.reflect;resolution:=optional;version="[1.7,2)",
+            org.bouncycastle.crypto*;resolution:=optional,
+            org.springframework.aop;resolution:=optional;version="[4,5)",
+            org.springframework.aop.framework;resolution:=optional;version="[4,5)",
+            org.springframework.aop.support;resolution:=optional;version="[4,5)",
+            org.springframework.beans;version="[4,5)",
+            org.springframework.beans.factory;version="[4,5)",
+            org.springframework.beans.propertyeditors;version="[4,5)",
+            org.springframework.context;version="[4,5)",
+            org.springframework.context.expression;version="[4,5)",
+            org.springframework.context.support;version="[4,5)",
+            org.springframework.core;version="[4,5)",
+            org.springframework.core.annotation;version="[4,5)",
+            org.springframework.core.io;version="[4,5)",
+            org.springframework.dao;resolution:=optional;version="[4,5)",
+            org.springframework.expression;resolution:=optional;version="[4,5)",
+            org.springframework.expression.spel.standard;resolution:=optional;version="[4,5)",
+            org.springframework.expression.spel.support;resolution:=optional;version="[4,5)",
+            org.springframework.jdbc.core;resolution:=optional;version="[4,5)",
+            org.springframework.jdbc.core.support;resolution:=optional;version="[4,5)",
+            org.springframework.util;version="[4,5)",
+            org.springframework.cache;resolution:=optional;version="[4,5)", 
+            org.springframework.context.event;resolution:=optional;version="[4,5)", 
+            org.springframework.core.task;resolution:=optional;version="[4,5)", 
+            org.springframework.scheduling;resolution:=optional;version="[4,5)"
+        </servicemix.osgi.import.pkg>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${pkgGroupId}</groupId>
+            <artifactId>${pkgArtifactId}</artifactId>
+            <version>${pkgVersion}</version>
+        </dependency>
+
+        <!-- sources -->
+        <dependency>
+            <groupId>${pkgGroupId}</groupId>
+            <artifactId>${pkgArtifactId}</artifactId>
+            <version>${pkgVersion}</version>
+            <classifier>sources</classifier>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>${pkgGroupId}:${pkgArtifactId}</include>
+                                </includes>
+                            </artifactSet>
+                            <filters>
+                                <filter>
+                                    <artifact>${pkgGroupId}:${pkgArtifactId}</artifact>
+                                    <excludes>
+                                        <exclude>**</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+                            <createDependencyReducedPom>true</createDependencyReducedPom>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/spring-security-core-4.1.0.RELEASE/src/main/resources/OSGI-INF/bundle.info
+++ b/spring-security-core-4.1.0.RELEASE/src/main/resources/OSGI-INF/bundle.info
@@ -1,0 +1,11 @@
+\u001B[1mSYNOPSIS\u001B[0m
+    ${project.description}
+
+    Original Maven URL:
+        \u001B[33mmvn:${pkgGroupId}/${pkgArtifactId}/${pkgVersion}\u001B[0m
+
+\u001B[1mDESCRIPTION\u001B[0m
+    Spring Framework Security Core module.
+
+\u001B[1mSEE ALSO\u001B[0m
+    \u001B[36mhttp://www.springsource.org/spring-framework\u001B[0m

--- a/spring-security-taglibs-4.1.0.RELEASE/pom.xml
+++ b/spring-security-taglibs-4.1.0.RELEASE/pom.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <!--
+
+        Licensed to the Apache Software Foundation (ASF) under one or more
+        contributor license agreements.  See the NOTICE file distributed with
+        this work for additional information regarding copyright ownership.
+        The ASF licenses this file to You under the Apache License, Version 2.0
+        (the "License"); you may not use this file except in compliance with
+        the License.  You may obtain a copy of the License at
+
+           http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+    -->
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.servicemix.bundles</groupId>
+        <artifactId>bundles-pom</artifactId>
+        <version>12</version>
+        <relativePath>../bundles-pom/pom.xml</relativePath>
+    </parent>
+
+    <groupId>org.apache.servicemix.bundles</groupId>
+    <artifactId>org.apache.servicemix.bundles.spring-security-taglibs</artifactId>
+    <version>4.1.0.RELEASE_1-SNAPSHOT</version>
+    <packaging>bundle</packaging>
+    <name>Apache ServiceMix :: Bundles :: ${pkgArtifactId}</name>
+
+    <scm>
+        <connection>scm:git:https://git-wip-us.apache.org/repos/asf/servicemix-bundles.git</connection>
+        <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/servicemix-bundles.git</developerConnection>
+        <url>https://git-wip-us.apache.org/repos/asf?p=servicemix-bundles.git</url>
+      <tag>HEAD</tag>
+  </scm>
+
+    <properties>
+        <pkgGroupId>org.springframework.security</pkgGroupId>
+        <pkgArtifactId>spring-security-taglibs</pkgArtifactId>
+        <pkgVersion>4.1.0.RELEASE</pkgVersion>
+        <servicemix.osgi.export.pkg>
+            org.springframework.security.taglibs
+        </servicemix.osgi.export.pkg>
+        <servicemix.osgi.import.pkg>
+            javax.servlet;version=0,
+            javax.servlet.http;version=0,
+            javax.servlet.jsp;version=0,
+            javax.servlet.jsp.tagext;version=0,
+            org.apache.commons.logging;version="[1.0.4, 2.0.0)",
+            org.springframework.beans;version="[4,5)",
+            org.springframework.context;version="[4,5)",
+            org.springframework.core;version="[4,5)",
+            org.springframework.expression;resolution:=optional;version="[4,5)",
+            org.springframework.security.access;version="[4.1,5)",
+            org.springframework.security.access.expression;version="[4.1,5)",
+            org.springframework.security.core;version="[4.1,5)",
+            org.springframework.security.core.context;version="[4.1,5)",
+            org.springframework.security.web;version="[4.1,5)",
+            org.springframework.security.web.access;version="[4.1,5)",
+            org.springframework.security.web.util;version="[4.1,5)",
+            org.springframework.security.web.context.support;version="[4.1,5)",
+            org.springframework.security.web.csrf;version="[4.1,5)",
+            org.springframework.util;version="[4,5)",
+            org.springframework.web.context;resolution:=optional;version="[4,5)",
+            org.springframework.web.context.support;resolution:=optional;version="[4,5)",
+            org.springframework.web.util;version="[4,5)"
+        </servicemix.osgi.import.pkg>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${pkgGroupId}</groupId>
+            <artifactId>${pkgArtifactId}</artifactId>
+            <version>${pkgVersion}</version>
+        </dependency>
+
+        <!-- sources -->
+        <dependency>
+            <groupId>${pkgGroupId}</groupId>
+            <artifactId>${pkgArtifactId}</artifactId>
+            <version>${pkgVersion}</version>
+            <classifier>sources</classifier>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>${pkgGroupId}:${pkgArtifactId}</include>
+                                </includes>
+                            </artifactSet>
+                            <filters>
+                                <filter>
+                                    <artifact>${pkgGroupId}:${pkgArtifactId}</artifact>
+                                    <excludes>
+                                        <exclude>**</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+                            <createDependencyReducedPom>true</createDependencyReducedPom>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/spring-security-taglibs-4.1.0.RELEASE/src/main/resources/OSGI-INF/bundle.info
+++ b/spring-security-taglibs-4.1.0.RELEASE/src/main/resources/OSGI-INF/bundle.info
@@ -1,0 +1,11 @@
+\u001B[1mSYNOPSIS\u001B[0m
+    ${project.description}
+
+    Original Maven URL:
+        \u001B[33mmvn:${pkgGroupId}/${pkgArtifactId}/${pkgVersion}\u001B[0m
+
+\u001B[1mDESCRIPTION\u001B[0m
+    Spring Framework Security Taglibs module.
+
+\u001B[1mSEE ALSO\u001B[0m
+    \u001B[36mhttp://www.springsource.org/spring-framework\u001B[0m

--- a/spring-security-web-4.1.0.RELEASE/pom.xml
+++ b/spring-security-web-4.1.0.RELEASE/pom.xml
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <!--
+
+        Licensed to the Apache Software Foundation (ASF) under one or more
+        contributor license agreements.  See the NOTICE file distributed with
+        this work for additional information regarding copyright ownership.
+        The ASF licenses this file to You under the Apache License, Version 2.0
+        (the "License"); you may not use this file except in compliance with
+        the License.  You may obtain a copy of the License at
+
+           http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+    -->
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.servicemix.bundles</groupId>
+        <artifactId>bundles-pom</artifactId>
+        <version>12</version>
+        <relativePath>../bundles-pom/pom.xml</relativePath>
+    </parent>
+
+    <groupId>org.apache.servicemix.bundles</groupId>
+    <artifactId>org.apache.servicemix.bundles.spring-security-web</artifactId>
+    <version>4.1.0.RELEASE_1-SNAPSHOT</version>
+    <packaging>bundle</packaging>
+    <name>Apache ServiceMix :: Bundles :: ${pkgArtifactId}</name>
+
+    <scm>
+        <connection>scm:git:https://git-wip-us.apache.org/repos/asf/servicemix-bundles.git</connection>
+        <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/servicemix-bundles.git</developerConnection>
+        <url>https://git-wip-us.apache.org/repos/asf?p=servicemix-bundles.git</url>
+      <tag>HEAD</tag>
+  </scm>
+
+    <properties>
+        <pkgGroupId>org.springframework.security</pkgGroupId>
+        <pkgArtifactId>spring-security-web</pkgArtifactId>
+        <pkgVersion>4.1.0.RELEASE</pkgVersion>
+        <servicemix.osgi.export.pkg>
+            org.springframework.security.web
+        </servicemix.osgi.export.pkg>
+        <servicemix.osgi.import.pkg>
+            javax.naming;resolution:=optional;version=0,
+            javax.rmi;resolution:=optional;version=0,
+            javax.security.auth;resolution:=optional;version=0,
+            javax.security.auth.login;resolution:=optional;version=0,
+            javax.servlet;resolution:=optional;version=0,
+            javax.servlet.http;resolution:=optional;version=0,
+            javax.xml.parsers;resolution:=optional;version=0,
+            org.apache.commons.logging;version="[1.0.4,2.0.0)",
+            org.aspectj.weaver.tools;resolution:=optional;version="[1.7,2)",
+            org.springframework.beans*;version="[4,5)",
+            org.springframework.context*;version="[4,5)",
+            org.springframework.core*;version="[4,5)",
+            org.springframework.dao;resolution:=optional;version="[4,5)",
+            org.springframework.expression;resolution:=optional;version="[4,5)",
+            org.springframework.expression.spel.standard;resolution:=optional;version="[4,5)",
+            org.springframework.expression.spel.support;resolution:=optional;version="[4,5)",
+            org.springframework.http;version="[4,5)",
+            org.springframework.jdbc.core;resolution:=optional;version="[4,5)",
+            org.springframework.jdbc.core.support;resolution:=optional;version="[4,5)", 
+            org.springframework.util;resolution:=optional;version="[4,5)",
+            org.springframework.security.access*;version="[4.1,5)",
+            org.springframework.security.authentication*;version="[4.1,5)",
+            org.springframework.security.core*;version="[4.1,5)",
+            org.springframework.security.concurrent*;version="[4.1,5)",
+            org.springframework.security.crypto.codec;version="[4.1,5)",
+            org.springframework.web*;version="[4,5)",
+            org.w3c.dom;resolution:=optional;version=0,
+            org.xml.sax;resolution:=optional;version=0
+        </servicemix.osgi.import.pkg>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${pkgGroupId}</groupId>
+            <artifactId>${pkgArtifactId}</artifactId>
+            <version>${pkgVersion}</version>
+        </dependency>
+
+        <!-- sources -->
+        <dependency>
+            <groupId>${pkgGroupId}</groupId>
+            <artifactId>${pkgArtifactId}</artifactId>
+            <version>${pkgVersion}</version>
+            <classifier>sources</classifier>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>${pkgGroupId}:${pkgArtifactId}</include>
+                                </includes>
+                            </artifactSet>
+                            <filters>
+                                <filter>
+                                    <artifact>${pkgGroupId}:${pkgArtifactId}</artifact>
+                                    <excludes>
+                                        <exclude>**</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+                            <createDependencyReducedPom>true</createDependencyReducedPom>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/spring-security-web-4.1.0.RELEASE/src/main/resources/OSGI-INF/bundle.info
+++ b/spring-security-web-4.1.0.RELEASE/src/main/resources/OSGI-INF/bundle.info
@@ -1,0 +1,11 @@
+\u001B[1mSYNOPSIS\u001B[0m
+    ${project.description}
+
+    Original Maven URL:
+        \u001B[33mmvn:${pkgGroupId}/${pkgArtifactId}/${pkgVersion}\u001B[0m
+
+\u001B[1mDESCRIPTION\u001B[0m
+    Spring Framework Security Web module.
+
+\u001B[1mSEE ALSO\u001B[0m
+    \u001B[36mhttp://www.springsource.org/spring-framework\u001B[0m


### PR DESCRIPTION
This PR includes ServiceMix bundles for:
- spring-security-acl-4.1.0.RELEASE
- spring-security-config-4.1.0.RELEASE
- spring-security-core-4.1.0.RELEASE
- spring-security-taglibs-4.1.0.RELEASE
- spring-security-web-4.1.0.RELEASE