### PR TITLE
Jest bundle has wrong dependency on httpasyncclient-osgi 4.1 packages

### DIFF
--- a/jest-0.1.6/pom.xml
+++ b/jest-0.1.6/pom.xml
@@ -69,7 +69,7 @@
             org.apache.http.entity;version="[4.4,5)",
             org.apache.http.impl.client;version="[4.4,5)",
             org.apache.http.impl.conn;version="[4.4,5)",
-            org.apache.http.impl.nio.client;version="[4.4,5)",
+            org.apache.http.impl.nio.client;version="[4.1,5)",
             org.apache.http.util;version="[4.4,5)",
             org.apache.commons.lang3;version="[3.3,4)",
             org.apache.commons.lang3.builder;version="[3.3,4)",


### PR DESCRIPTION
Dependency on org.apache.httpcomponents/httpasyncclient-osgi incorrectly reference version 4.4 of packages exported by it
