### PR TITLE
Create OSGi bundle for Apache Tinkerpop 3.2.4 - gremlin-driver-shaded

### DIFF
--- a/gremlin-driver-3.2.4-shaded/pom.xml
+++ b/gremlin-driver-3.2.4-shaded/pom.xml
@@ -84,6 +84,15 @@
                     <target>1.8</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <createDependencyReducedPom>true</createDependencyReducedPom>
+                    </instructions>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/gremlin-driver-3.2.4-shaded/pom.xml
+++ b/gremlin-driver-3.2.4-shaded/pom.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <!--
+
+        Licensed to the Apache Software Foundation (ASF) under one or more
+        contributor license agreements.  See the NOTICE file distributed with
+        this work for additional information regarding copyright ownership.
+        The ASF licenses this file to You under the Apache License, Version 2.0
+        (the "License"); you may not use this file except in compliance with
+        the License.  You may obtain a copy of the License at
+
+           http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+    -->
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.servicemix.bundles</groupId>
+        <artifactId>bundles-pom</artifactId>
+        <version>13</version>
+        <relativePath>../bundles-pom/pom.xml</relativePath>
+    </parent>
+
+    <groupId>org.apache.servicemix.bundles</groupId>
+    <artifactId>org.apache.servicemix.bundles.gremlin-driver-shaded</artifactId>
+    <version>3.2.4_1-SNAPSHOT</version>
+    <packaging>bundle</packaging>
+    <name>Apache ServiceMix :: Bundles :: ${pkgArtifactIdShaded}</name>
+    <description>This OSGi bundle wraps ${pkgArtifactId} ${pkgVersion} shaded jar file.</description>
+
+    <properties>
+        <pkgGroupId>org.apache.tinkerpop</pkgGroupId>
+        <pkgArtifactId>gremlin-driver</pkgArtifactId>
+        <pkgArtifactIdShaded>gremlin-driver-shaded</pkgArtifactIdShaded>
+        <pkgVersion>3.2.4</pkgVersion>
+        <servicemix.osgi.export.pkg>
+            org.apache.tinkerpop.gremlin.*
+        </servicemix.osgi.export.pkg>
+        <servicemix.osgi.import.pkg>
+            sun.nio.ch;resolution:=optional,
+            *
+        </servicemix.osgi.import.pkg>
+        <servicemix.osgi.private.pkg>
+            com.carrotsearch.hppc*,
+            com.jcabi.*,
+            org.apache.tinkerpop.shaded.*,
+            org.javatuples*,
+            org.yaml.snakeyaml*
+        </servicemix.osgi.private.pkg>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${pkgGroupId}</groupId>
+            <artifactId>${pkgArtifactId}</artifactId>
+            <version>${pkgVersion}</version>
+            <optional>false</optional>
+        </dependency>
+
+        <!-- sources -->
+        <dependency>
+            <groupId>${pkgGroupId}</groupId>
+            <artifactId>${pkgArtifactId}</artifactId>
+            <version>${pkgVersion}</version>
+            <classifier>sources</classifier>
+            <optional>false</optional>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/gremlin-driver-3.2.4-shaded/src/main/resources/OSGI-INF/bundle.info
+++ b/gremlin-driver-3.2.4-shaded/src/main/resources/OSGI-INF/bundle.info
@@ -1,0 +1,12 @@
+\u001B[1mSYNOPSIS\u001B[0m
+    ${project.description}
+
+    Original Maven URL:
+        \u001B[33mmvn:${pkgGroupId}/${pkgArtifactId}/${pkgVersion}\u001B[0m
+
+\u001B[1mDESCRIPTION\u001B[0m
+    Apache TinkerPop™ is a graph computing framework for both graph databases (OLTP)
+    and graph analytic systems (OLAP).
+
+\u001B[1mSEE ALSO\u001B[0m
+    \u001B[36mhttp://tinkerpop.apache.org\u001B[0m


### PR DESCRIPTION
Shade gremlin-driver, gremlin-core and gremlin-shaded modules from tinkerpop into a single bundle, together with non-OSGi 3rd-party deps

The object of this bundle is to allow remote tinkerpop servers to be accessed from OSGi environments, as I showcased here: https://github.com/CMoH/tinkerpop-osgi-samples