### PR TITLE
Janusgraph OSGi bundle

### DIFF
--- a/gremlin-driver-3.2.6/pom.xml
+++ b/gremlin-driver-3.2.6/pom.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <!--
+
+        Licensed to the Apache Software Foundation (ASF) under one or more
+        contributor license agreements.  See the NOTICE file distributed with
+        this work for additional information regarding copyright ownership.
+        The ASF licenses this file to You under the Apache License, Version 2.0
+        (the "License"); you may not use this file except in compliance with
+        the License.  You may obtain a copy of the License at
+
+           http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+    -->
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.servicemix.bundles</groupId>
+        <artifactId>bundles-pom</artifactId>
+        <version>13</version>
+        <relativePath>../bundles-pom/pom.xml</relativePath>
+    </parent>
+
+    <groupId>org.apache.servicemix.bundles</groupId>
+    <artifactId>org.apache.servicemix.bundles.gremlin-driver</artifactId>
+    <version>3.2.6_1-SNAPSHOT</version>
+    <packaging>bundle</packaging>
+    <name>Apache ServiceMix :: Bundles :: ${pkgArtifactId}</name>
+    <description>This OSGi bundle wraps ${pkgArtifactId} ${pkgVersion} shaded jar file.</description>
+
+    <scm>
+        <connection>scm:git:https://git-wip-us.apache.org/repos/asf/servicemix-bundles.git</connection>
+        <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/servicemix-bundles.git</developerConnection>
+        <url>https://git-wip-us.apache.org/repos/asf?p=servicemix-bundles.git</url>
+      <tag>HEAD</tag>
+  </scm>
+
+    <properties>
+        <pkgGroupId>org.apache.tinkerpop</pkgGroupId>
+        <pkgArtifactId>gremlin-driver</pkgArtifactId>
+        <pkgArtifactIdShaded>gremlin-driver-shaded</pkgArtifactIdShaded>
+        <pkgVersion>3.2.6</pkgVersion>
+        <servicemix.osgi.export.pkg>
+            org.apache.tinkerpop.*
+        </servicemix.osgi.export.pkg>
+        <servicemix.osgi.import.pkg>
+            sun.nio.ch;resolution:=optional,
+            *
+        </servicemix.osgi.import.pkg>
+        <servicemix.osgi.private.pkg>
+            com.carrotsearch.hppc*,
+            com.jcabi.*,
+            com.squareup.javapoet,
+            org.javatuples*,
+            org.yaml.snakeyaml*
+        </servicemix.osgi.private.pkg>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${pkgGroupId}</groupId>
+            <artifactId>${pkgArtifactId}</artifactId>
+            <version>${pkgVersion}</version>
+            <optional>false</optional>
+        </dependency>
+
+        <!-- sources -->
+        <dependency>
+            <groupId>${pkgGroupId}</groupId>
+            <artifactId>${pkgArtifactId}</artifactId>
+            <version>${pkgVersion}</version>
+            <classifier>sources</classifier>
+            <optional>false</optional>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <createDependencyReducedPom>true</createDependencyReducedPom>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/gremlin-driver-3.2.6/src/main/resources/OSGI-INF/bundle.info
+++ b/gremlin-driver-3.2.6/src/main/resources/OSGI-INF/bundle.info
@@ -1,0 +1,12 @@
+\u001B[1mSYNOPSIS\u001B[0m
+    ${project.description}
+
+    Original Maven URL:
+        \u001B[33mmvn:${pkgGroupId}/${pkgArtifactId}/${pkgVersion}\u001B[0m
+
+\u001B[1mDESCRIPTION\u001B[0m
+    Apache TinkerPop™ is a graph computing framework for both graph databases (OLTP)
+    and graph analytic systems (OLAP).
+
+\u001B[1mSEE ALSO\u001B[0m
+    \u001B[36mhttp://tinkerpop.apache.org\u001B[0m

--- a/janusgraph-core-0.2.0/pom.xml
+++ b/janusgraph-core-0.2.0/pom.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <!--
+
+        Licensed to the Apache Software Foundation (ASF) under one or more
+        contributor license agreements.  See the NOTICE file distributed with
+        this work for additional information regarding copyright ownership.
+        The ASF licenses this file to You under the Apache License, Version 2.0
+        (the "License"); you may not use this file except in compliance with
+        the License.  You may obtain a copy of the License at
+
+           http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+    -->
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.servicemix.bundles</groupId>
+        <artifactId>bundles-pom</artifactId>
+        <version>13</version>
+        <relativePath>../bundles-pom/pom.xml</relativePath>
+    </parent>
+
+    <groupId>org.apache.servicemix.bundles</groupId>
+    <artifactId>org.apache.servicemix.bundles.janusgraph-core</artifactId>
+    <version>0.2.0_1-SNAPSHOT</version>
+    <packaging>bundle</packaging>
+    <name>Apache ServiceMix :: Bundles :: ${pkgArtifactId}</name>
+    <description>This OSGi bundle wraps ${pkgArtifactId} ${pkgVersion} shaded jar file.</description>
+
+    <scm>
+        <connection>scm:git:https://git-wip-us.apache.org/repos/asf/servicemix-bundles.git</connection>
+        <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/servicemix-bundles.git</developerConnection>
+        <url>https://git-wip-us.apache.org/repos/asf?p=servicemix-bundles.git</url>
+        <tag>HEAD</tag>
+    </scm>
+
+    <properties>
+        <tinkerpop.version>3.2.6</tinkerpop.version>
+        <pkgGroupId>org.janusgraph</pkgGroupId>
+        <pkgArtifactId>janusgraph-core</pkgArtifactId>
+        <pkgArtifactIdShaded>janusgraph-core-shaded</pkgArtifactIdShaded>
+        <pkgVersion>0.2.0</pkgVersion>
+        <servicemix.osgi.export.pkg>
+            org.janusgraph.*
+        </servicemix.osgi.export.pkg>
+        <servicemix.osgi.import.pkg>
+            com.sun.jdi*;resolution:=optional,
+            sun.nio.ch;resolution:=optional,
+            !org.apache.tinkerpop.gremlin.server,
+            org.apache.tinkerpop.*,
+            !com.vividsolutions.jts.geom,
+            !info.ganglia.gmetric4j*,
+            !org.acplt.oncrpc,
+            !org.reflections*,
+            *
+        </servicemix.osgi.import.pkg>
+        <servicemix.osgi.private.pkg>
+            com.carrotsearch.hppc*,
+            com.codahale*,
+            com.jcabi.*,
+            com.squareup.javapoet,
+            javassist*,
+            org.cliffc.high_scale_lib,
+            org.javatuples*,
+            org.mindrot.jbcrypt,
+            org.yaml.snakeyaml*
+        </servicemix.osgi.private.pkg>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${pkgGroupId}</groupId>
+            <artifactId>${pkgArtifactId}</artifactId>
+            <version>${pkgVersion}</version>
+            <optional>false</optional>
+        </dependency>
+
+        <!-- sources -->
+        <dependency>
+            <groupId>${pkgGroupId}</groupId>
+            <artifactId>${pkgArtifactId}</artifactId>
+            <version>${pkgVersion}</version>
+            <classifier>sources</classifier>
+            <optional>false</optional>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <createDependencyReducedPom>true</createDependencyReducedPom>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/janusgraph-core-0.2.0/src/main/resources/OSGI-INF/bundle.info
+++ b/janusgraph-core-0.2.0/src/main/resources/OSGI-INF/bundle.info
@@ -1,0 +1,13 @@
+\u001B[1mSYNOPSIS\u001B[0m
+    ${project.description}
+
+    Original Maven URL:
+        \u001B[33mmvn:${pkgGroupId}/${pkgArtifactId}/${pkgVersion}\u001B[0m
+
+\u001B[1mDESCRIPTION\u001B[0m
+    JanusGraph is a scalable graph database optimized for storing and querying
+    graphs containing hundreds of billions of vertices and edges distributed
+    across a multi-machine cluster.
+
+\u001B[1mSEE ALSO\u001B[0m
+    \u001B[36mhttp://janusgraph.org/\u001B[0m

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,7 @@
         <module>zxing-3.3.1</module>
         <module>gwt-servlet-2.8.2</module>
         <module>gremlin-driver-3.2.6</module>
+        <module>janusgraph-core-0.2.0</module>
     </modules>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,7 @@
         <module>htmlunit-2.28</module>
         <module>zxing-3.3.1</module>
         <module>gwt-servlet-2.8.2</module>
+        <module>gremlin-driver-3.2.6</module>
     </modules>
 
 </project>


### PR DESCRIPTION
Add a OSGi bundle for janusgraph-core. The goal is to be able to access janusgraph servers remotely from OSGi environments. I've added an example at https://github.com/CMoH/tinkerpop-osgi-samples on how this bundle is usable to connect to a remote server.

Also added OSGi bundle for gremlin-driver-3.2.6, since it is a dependency of janusgraph-core-0.2.0