### PR TITLE
Fixing Guava version OSGi imports as reflections-0.9.11 is using 20.0

### DIFF
--- a/reflections-0.9.11/pom.xml
+++ b/reflections-0.9.11/pom.xml
@@ -51,11 +51,11 @@
         </servicemix.osgi.export.pkg>
         <servicemix.osgi.import.pkg>
             org.osgi.framework,
-            com.google.common.base;resolution:=optional;version="[18.0,19)",
-            com.google.common.cache;resolution:=optional;version="[18.0,19)",
-	    com.google.common.collect;resolution:=optional;version="[18.0,19)",
-	    com.google.common.io;resolution:=optional;version="[18.0,19)",
-	    com.google.gson;resolution:=optional,
+            com.google.common.base;resolution:=optional;version="[20.0,21)",
+            com.google.common.cache;resolution:=optional;version="[20.0,21)",
+            com.google.common.collect;resolution:=optional;version="[20.0,21)",
+            com.google.common.io;resolution:=optional;version="[20.0,21)",
+            com.google.gson;resolution:=optional,
             javassist;resolution:=optional,
             javassist.expr;resolution:=optional,
 	    javassist.bytecode;resolution:=optional,


### PR DESCRIPTION
Hey guys,

Run into this issue recently while importing `org.apache.servicemix.bundles.reflections-0.9.11_1` servicemix bundle. The underlying `reflections-0.9.11` library is declaring dependency on Guava `20.0` while the OSGi imports are still referring to `[18.0, 19)`. 

Best Regards,
    Andriy Redko