### PR TITLE
Marked optional imports for Spring Security as such

### DIFF
--- a/spring-security-config-5.1.2.RELEASE/pom.xml
+++ b/spring-security-config-5.1.2.RELEASE/pom.xml
@@ -53,11 +53,14 @@
 			org.aspectj.*;resolution:=optional,
 			org.openid4java.*;resolution:=optional,
 			org.springframework.jdbc.*;resolution:=optional,
+			org.springframework.ldap*;resolution:=optional,
 			org.springframework.messaging*;resolution:=optional,
 			org.springframework.web*;resolution:=optional,
+			org.springframework.security.ldap*;resolution:=optional,
 			org.springframework.security.messaging*;resolution:=optional,
 			org.springframework.security.oauth2*;resolution:=optional,
 			org.springframework.security.openid*;resolution:=optional,
+			org.springframework.security.web*;resolution:=optional,
             *
         </servicemix.osgi.import.pkg>
     </properties>


### PR DESCRIPTION
The Web and LDAP imports for Spring Security are not mandatory.