### PR TITLE
[SM-3964] Create OSGi bundle for aws-java-sdk-s3 1.11.496

### DIFF
--- a/aws-java-sdk-s3-1.11.496/pom.xml
+++ b/aws-java-sdk-s3-1.11.496/pom.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <!--
+
+        Licensed to the Apache Software Foundation (ASF) under one or more
+        contributor license agreements.  See the NOTICE file distributed with
+        this work for additional information regarding copyright ownership.
+        The ASF licenses this file to You under the Apache License, Version 2.0
+        (the "License"); you may not use this file except in compliance with
+        the License.  You may obtain a copy of the License at
+
+           http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+    -->
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.servicemix.bundles</groupId>
+        <artifactId>bundles-pom</artifactId>
+        <version>13</version>
+        <relativePath>../bundles-pom/pom.xml</relativePath>
+    </parent>
+
+    <groupId>org.apache.servicemix.bundles</groupId>
+    <artifactId>org.apache.servicemix.bundles.aws-java-sdk-s3</artifactId>
+    <packaging>bundle</packaging>
+    <version>1.11.496_1-SNAPSHOT</version>
+    <name>Apache ServiceMix :: Bundles :: ${pkgArtifactId}</name>
+    <description>This OSGi bundle wraps ${pkgArtifactId} ${pkgVersion} jar file.</description>
+
+    <scm>
+        <connection>scm:git:https://gitbox.apache.org/repos/asf/servicemix-bundles.git</connection>
+        <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/servicemix-bundles.git</developerConnection>
+        <url>https://gitbox.apache.org/repos/asf?p=servicemix-bundles.git</url>
+    <tag>HEAD</tag>
+  </scm>
+
+    <properties>
+        <pkgGroupId>com.amazonaws</pkgGroupId>
+        <pkgArtifactId>aws-java-sdk-s3</pkgArtifactId>
+        <pkgVersion>1.11.496</pkgVersion>
+        <servicemix.osgi.export.pkg>
+            com.amazonaws.services.s3*,
+            com.amazonaws.auth*
+        </servicemix.osgi.export.pkg>
+        <servicemix.osgi.import.pkg>
+            *
+        </servicemix.osgi.import.pkg>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${pkgGroupId}</groupId>
+            <artifactId>${pkgArtifactId}</artifactId>
+            <version>${pkgVersion}</version>
+        </dependency>
+
+        <!-- sources
+        Not available on Central
+        <dependency>
+            <groupId>${pkgGroupId}</groupId>
+            <artifactId>${pkgArtifactId}</artifactId>
+            <version>${pkgVersion}</version>
+            <classifier>sources</classifier>
+        </dependency>
+        -->
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>${pkgGroupId}:${pkgArtifactId}</include>
+                                </includes>
+                            </artifactSet>
+                            <filters>
+                                <filter>
+                                    <artifact>${pkgGroupId}:${pkgArtifactId}</artifact>
+                                    <includes>
+                                        <include>META-INF/services/**</include>
+                                    </includes>
+                                </filter>
+                            </filters>
+                            <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+                            <createDependencyReducedPom>true</createDependencyReducedPom>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/aws-java-sdk-s3-1.11.496/src/main/resources/OSGI-INF/bundle.info
+++ b/aws-java-sdk-s3-1.11.496/src/main/resources/OSGI-INF/bundle.info
@@ -1,0 +1,24 @@
+\u001B[1mSYNOPSIS\u001B[0m
+    ${project.description}
+
+    Original Maven URL:
+        \u001B[33mmvn:${pkgGroupId}/${pkgArtifactId}/${pkgVersion}\u001B[0m
+
+\u001B[1mDESCRIPTION\u001B[0m
+    Since early 2006, Amazon Web Services (AWS) has provided companies of all sizes with an infrastructure web
+    services platform in the cloud. With AWS you can requisition compute power, storage, and other
+    services–gaining access to a suite of elastic IT infrastructure services as your business demands them.
+    With AWS you have the flexibility to choose whichever development platform or programming model makes the
+    most sense for the problems you’re trying to solve. You pay only for what you use, with no up-front expenses
+    or long-term commitments, making AWS the most cost-effective way to deliver your application to your
+    customers and clients. And, with AWS, you can take advantage of Amazon.com’s global computing infrastructure
+    that is the backbone of Amazon.com’s multi-billion retail business and transactional enterprise whose
+    scalable, reliable, and secure distributed computing infrastructure has been honed for over a decade.
+
+    Using Amazon Web Services, an e-commerce web site can weather unforeseen demand with ease; a pharmaceutical
+    company can “rent” computing power to execute large-scale simulations; a media company can serve unlimited
+    videos, music, and more; and an enterprise can deploy bandwidth-consuming services and training to its
+    mobile workforce.
+
+\u001B[1mSEE ALSO\u001B[0m
+    \u001B[36mhttp://aws.amazon.com/\u001B[0m

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
         <module>kafka-clients-2.1.1</module>
         <module>kafka-streams-2.1.1</module>
         <module>aws-java-sdk-core-1.11.496</module>
+        <module>aws-java-sdk-s3-1.11.496</module>
     </modules>
 
 </project>


### PR DESCRIPTION
@jbonofre 

Can we follow a path like this one and releasing the aws-sdk-java-core as a separated bundle? In this way we can split camel-aws in multiple components and install only what we need.