### PR TITLE
[SECURITY] Use HTTPS to resolve dependencies in Maven Build

### DIFF
--- a/casbah-3.1.1/pom.xml
+++ b/casbah-3.1.1/pom.xml
@@ -61,7 +61,7 @@
 	<repositories>
         <repository>
             <id>releases.scala-tools.org</id>
-            <url>http://scala-tools.org/repo-releases</url>
+            <url>https://scala-tools.org/repo-releases</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/gentlyweb-utils-1.5/pom.xml
+++ b/gentlyweb-utils-1.5/pom.xml
@@ -50,7 +50,7 @@
     <repositories>
         <repository>
             <id>fusesource</id>
-            <url>http://repo.fusesource.com/nexus/content/groups/public/</url>
+            <url>https://repo.fusesource.com/nexus/content/groups/public/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/hapi-0.5.1/pom.xml
+++ b/hapi-0.5.1/pom.xml
@@ -65,7 +65,7 @@
         <repository>
             <id>servicemix-m2-repo</id>
             <name>Servicemix Maven2 Repository</name>
-            <url>http://svn.apache.org/repos/asf/servicemix/m2-repo</url>
+            <url>https://svn.apache.org/repos/asf/servicemix/m2-repo</url>
         </repository>
     </repositories>
 

--- a/hsqldb-1.8.0.10/pom.xml
+++ b/hsqldb-1.8.0.10/pom.xml
@@ -39,7 +39,7 @@
         <repository>
             <id>fusesource.m2all</id>
             <name>Fusesource Release Repository</name>
-            <url>http://repo.fusesource.com/maven2-all</url>
+            <url>https://repo.fusesource.com/maven2-all</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>

--- a/jain-sip-ri-1.2.169/pom.xml
+++ b/jain-sip-ri-1.2.169/pom.xml
@@ -38,7 +38,7 @@
     <repositories>
         <repository>
             <id>jboss</id>
-            <url>http://repository.jboss.org/nexus/content/groups/public/</url>
+            <url>https://repository.jboss.org/nexus/content/groups/public/</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>

--- a/javassist-3.12.1.GA/pom.xml
+++ b/javassist-3.12.1.GA/pom.xml
@@ -51,7 +51,7 @@
         <repository>
             <id>jboss</id>
             <name>New JBoss Maven2 Repository</name>
-            <url>http://repository.jboss.org/maven2-brew/</url>
+            <url>https://repository.jboss.org/maven2-brew/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/jsmpp-2.1.0/pom.xml
+++ b/jsmpp-2.1.0/pom.xml
@@ -88,7 +88,7 @@
         <repository>
             <id>servicemix</id>
             <name>Apache ServiceMix Repository</name>
-            <url>http://svn.apache.org/repos/asf/servicemix/m2-repo</url>
+            <url>https://svn.apache.org/repos/asf/servicemix/m2-repo</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/neo4j-3.5.12/pom.xml
+++ b/neo4j-3.5.12/pom.xml
@@ -85,7 +85,7 @@
         <repository>
             <id>neo4j.repo</id>
             <name>neo4j Repository</name>
-            <url>http://m2.neo4j.org/content/repositories/releases</url>
+            <url>https://m2.neo4j.org/content/repositories/releases</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/netty-3.2.10.Final/pom.xml
+++ b/netty-3.2.10.Final/pom.xml
@@ -61,7 +61,7 @@
             <!-- JBoss Maven2 Repository -->
             <id>jboss.m2</id>
             <name>JBoss Maven2 Repository</name>
-            <url>http://repository.jboss.org/nexus/content/groups/public</url>
+            <url>https://repository.jboss.org/nexus/content/groups/public</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/orbitz-consul-client-1.3.3/pom.xml
+++ b/orbitz-consul-client-1.3.3/pom.xml
@@ -115,7 +115,7 @@
             </snapshots>
             <id>central</id>
             <name>bintray</name>
-            <url>http://jcenter.bintray.com</url>
+            <url>https://jcenter.bintray.com</url>
         </repository>
     </repositories>
 </project>

--- a/restlet-1.1.10/pom.xml
+++ b/restlet-1.1.10/pom.xml
@@ -64,7 +64,7 @@
         <repository>
             <id>reslet.m2</id>
             <name>Restlet Maven2 Repository</name>
-            <url>http://maven.restlet.org</url>
+            <url>https://maven.restlet.org</url>
         </repository>
     </repositories>
 

--- a/rome-1.0/pom.xml
+++ b/rome-1.0/pom.xml
@@ -55,7 +55,7 @@
         <repository>
             <id>java.net</id>
             <name>Java.net Maven Repository</name>
-            <url>http://download.java.net/maven/2</url>
+            <url>https://download.java.net/maven/2</url>
         </repository>
     </repositories>
     

--- a/scalaj-collection-1.0/pom.xml
+++ b/scalaj-collection-1.0/pom.xml
@@ -50,7 +50,7 @@
 	<repositories>
         <repository>
             <id>releases.scala-tools.org</id>
-            <url>http://scala-tools.org/repo-releases</url>
+            <url>https://scala-tools.org/repo-releases</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/smack-3.2.1/pom.xml
+++ b/smack-3.2.1/pom.xml
@@ -98,7 +98,7 @@
         <repository>
             <id>smx-m2-repo</id>
             <name>ServiceMix Maven Repository</name>
-            <url>http://svn.apache.org/repos/asf/servicemix/m2-repo</url>
+            <url>https://svn.apache.org/repos/asf/servicemix/m2-repo</url>
         </repository>
     </repositories>
 

--- a/splunk-1.6.5.0/pom.xml
+++ b/splunk-1.6.5.0/pom.xml
@@ -71,7 +71,7 @@
         <repository>
             <id>splunk</id>
             <name>Splunk Artifactory</name>
-            <url>http://splunk.artifactoryonline.com/splunk/ext-releases-local/</url>
+            <url>https://splunk.artifactoryonline.com/splunk/ext-releases-local/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>


### PR DESCRIPTION
[![mitm_build](https://user-images.githubusercontent.com/1323708/59226671-90645200-8ba1-11e9-8ab3-39292bef99e9.jpeg)](https://medium.com/@jonathan.leitschuh/want-to-take-over-the-java-ecosystem-all-you-need-is-a-mitm-1fc329d898fb?source=friends_link&sk=3c99970c55a899ad9ef41f126efcde0e)

- [Want to take over the Java ecosystem? All you need is a MITM!](https://medium.com/@jonathan.leitschuh/want-to-take-over-the-java-ecosystem-all-you-need-is-a-mitm-1fc329d898fb?source=friends_link&sk=3c99970c55a899ad9ef41f126efcde0e)
- [Update: Want to take over the Java ecosystem? All you need is a MITM!](https://medium.com/bugbountywriteup/update-want-to-take-over-the-java-ecosystem-all-you-need-is-a-mitm-d069d253fe23?source=friends_link&sk=8c8e52a7d57b98d0b7e541665688b454)

---

This is a security fix for a  vulnerability in your [Apache Maven](https://maven.apache.org/) `pom.xml` file(s).

The build files indicate that this project is resolving dependencies over HTTP instead of HTTPS.
This leaves your build vulnerable to allowing a [Man in the Middle](https://en.wikipedia.org/wiki/Man-in-the-middle_attack) (MITM) attackers to execute arbitrary code on your or your computer or CI/CD system.

This vulnerability has a CVSS v3.0 Base Score of [8.1/10](https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector=AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H).

[POC code](https://max.computer/blog/how-to-take-over-the-computer-of-any-java-or-clojure-or-scala-developer/) has existed since 2014 to maliciously compromise a JAR file in-flight.
MITM attacks against HTTP are [increasingly common](https://security.stackexchange.com/a/12050), for example [Comcast is known to have done it to their own users](https://thenextweb.com/insights/2017/12/11/comcast-continues-to-inject-its-own-code-into-websites-you-visit/#).

This contribution is a part of a submission to the [GitHub Security Lab](https://securitylab.github.com/) Bug Bounty program.

## Detecting this and Future Vulnerabilities

This vulnerability was automatically detected by [LGTM.com](https://lgtm.com) using this [CodeQL Query](https://lgtm.com/rules/1511115648721/).

As of September 2019 LGTM.com and Semmle are [officially a part of GitHub](https://github.blog/2019-09-18-github-welcomes-semmle/).

You can automatically detect future vulnerabilities like this by enabling the free (for open-source) [LGTM App](https://github.com/marketplace/lgtm).

I'm not an employee of GitHub nor of Semmle, I'm simply a user of [LGTM.com](https://lgtm.com) and an open-source security researcher.

## Source

Yes, this contribution was automatically generated, however, the code to generate this PR was lovingly hand crafted to bring this security fix to your repository.

The source code that generated and submitted this PR can be found here:
[JLLeitschuh/bulk-security-pr-generator](https://github.com/JLLeitschuh/bulk-security-pr-generator)

## Opting-Out

If you'd like to opt-out of future automated security vulnerability fixes like this, please consider adding a file called
`.github/GH-ROBOTS.txt` to your repository with the line:

```
User-agent: JLLeitschuh/bulk-security-pr-generator
Disallow: *
```

This bot will respect the [ROBOTS.txt](https://moz.com/learn/seo/robotstxt) format for future contributions.

Alternatively, if this project is no longer actively maintained, consider [archiving](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-archiving-repositories) the repository.

## CLA Requirements

_This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions._

It is unlikely that I'll be able to directly sign CLAs. However, all contributed commits are already automatically signed-off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin 
> (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
>
> \- [Git Commit Signoff documentation](https://developercertificate.org/)

If signing your organization's CLA is a strict-requirement for merging this contribution, please feel free to close this PR.

## Tracking

All PR's generated as part of this fix are tracked here: 
https://github.com/JLLeitschuh/bulk-security-pr-generator/issues/2