### PR TITLE
camel-elasticsearch-rest dependencies

### DIFF
--- a/elasticsearch-client-6.1.1/pom.xml
+++ b/elasticsearch-client-6.1.1/pom.xml
@@ -46,16 +46,47 @@
         <pkgGroupId>org.elasticsearch.client</pkgGroupId>
         <pkgVersion>6.1.1</pkgVersion>
         <servicemix.osgi.export>
-            org.elasticsearch.client;version="${pkgVersion}";-split-package:=merge-first,
+            org.elasticsearch.action.*;version="${pkgVersion}";-split-package:=merge-first,
+            org.elasticsearch.client.node;version="${pkgVersion}";-split-package:=merge-first,
             org.elasticsearch.client.sniff;version="${pkgVersion}";-split-package:=merge-first,
-            org.elasticsearch.transport.client;version="${pkgVersion}";-split-package:=merge-first,
-            org.elasticsearch.client.transport;version="${pkgVersion}";-split-package:=merge-first,
             org.elasticsearch.client.support;version="${pkgVersion}";-split-package:=merge-first,
-            org.elasticsearch.client.node;version="${pkgVersion}";-split-package:=merge-first
+            org.elasticsearch.client.transport;version="${pkgVersion}";-split-package:=merge-first,
+            org.elasticsearch.client;version="${pkgVersion}";-split-package:=merge-first,
+            org.elasticsearch.common.*;version="${pkgVersion}";-split-package:=merge-first,
+            org.elasticsearch.indices;version="${pkgVersion}";-split-package:=merge-first,
+            org.elasticsearch.index.*;version="${pkgVersion}";-split-package:=merge-first,
+            org.elasticsearch.plugins.*;version="${pkgVersion}";-split-package:=merge-first,
+            org.elasticsearch.rest;version="${pkgVersion}";-split-package:=merge-first,
+            org.elasticsearch.rest.action;version="${pkgVersion}";-split-package:=merge-first,
+            org.elasticsearch.search.*;version="${pkgVersion}";-split-package:=merge-first,
+            org.elasticsearch.tasks.*;version="${pkgVersion}";-split-package:=merge-first,
+            org.elasticsearch.transport.*;version="${pkgVersion}";-split-package:=merge-first,
+            org.elasticsearch.transport.client;version="${pkgVersion}";-split-package:=merge-first,
+            org.elasticsearch;version="${pkgVersion}";-split-package:=merge-first,
         </servicemix.osgi.export>
         <servicemix.osgi.import.pkg>
-            *;resolution:=optional
+            com.fasterxml.jackson.core.base;version="[2.8,3)",
+            com.fasterxml.jackson.core.filter;version="[2.8,3)",
+            com.fasterxml.jackson.core.io;version="[2.8,3)",
+            com.fasterxml.jackson.core.util;version="[2.8,3)",
+            com.fasterxml.jackson.core;version="[2.8,3)",
+            com.fasterxml.jackson.dataformat.smile;version="[2.8,3)",
+            com.fasterxml.jackson.dataformat.yaml;version="[2.8,3)",
+            javax.net.ssl,
+            org.apache.commons.logging,
+            org.apache.http.*,
+            org.apache.logging.log4j.*,
+            org.apache.lucene.*,
+            org.joda.time.*,
         </servicemix.osgi.import.pkg>
+        <servicemix.osgi.private.pkg>
+            org.apache.lucene.index.memory;-split-package:=merge-first,
+            org.apache.lucene.search.*;-split-package:=merge-first,
+            org.apache.lucene.spatial.*;-split-package:=merge-first,
+            org.apache.lucene.spatial3d.*;-split-package:=merge-first,
+            org.elasticsearch.cluster.*;-split-package:=merge-first,
+            com.carrotsearch.hppc*,
+        </servicemix.osgi.private.pkg>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
This tweaks the configuration in order for the camel-elasticsearch-rest
to be able to work (in version 2.2x).