### PR TITLE
spring-ws-support should be a fragment bundle.

### DIFF
--- a/spring-ws-support-2.4.2.RELEASE/pom.xml
+++ b/spring-ws-support-2.4.2.RELEASE/pom.xml
@@ -48,6 +48,9 @@
         <servicemix.osgi.export.pkg>
             org.springframework.ws.transport
         </servicemix.osgi.export.pkg>
+        <servicemix.osgi.fragment.host>
+            ${project.groupId}.spring-ws-core
+        </servicemix.osgi.fragment.host>
         <servicemix.osgi.import.pkg>
             com.sun.mail.imap;resolution:=optional, 
             com.sun.net.httpserver;resolution:=optional, 

--- a/spring-ws-support-3.0.9.RELEASE/pom.xml
+++ b/spring-ws-support-3.0.9.RELEASE/pom.xml
@@ -48,6 +48,9 @@
         <servicemix.osgi.export.pkg>
             org.springframework.ws.transport
         </servicemix.osgi.export.pkg>
+        <servicemix.osgi.fragment.host>
+            ${project.groupId}.spring-ws-core
+        </servicemix.osgi.fragment.host>
         <servicemix.osgi.import.pkg>
             com.sun.mail.imap;resolution:=optional, 
             com.sun.net.httpserver;resolution:=optional, 


### PR DESCRIPTION
This bundle adds extra classes to spring-ws-core and exports some of the
same packages. It should attach to that bundle and complement it.

If deployed as it currently is, it will result in use constraint
violations for importing bundles since packages like
org.springframework.ws.transport will resolve via two dependency chains.

The last upstream version with OSGi metadata also packaged this bundle
as a fragment.

https://repo1.maven.org/maven2/org/springframework/ws/spring-ws-support/2.1.4.RELEASE/spring-ws-support-2.1.4.RELEASE.jar