### PR TITLE
XStreamMarshaller broken because of missing package import

### DIFF
--- a/spring-oxm-5.2.8.RELEASE/pom.xml
+++ b/spring-oxm-5.2.8.RELEASE/pom.xml
@@ -91,6 +91,7 @@
             org.springframework.core.type.classreading;version="[${pkgVersion},5.3)",
             org.springframework.core.type.filter;version="[${pkgVersion},5.3)",
             org.springframework.util;version="[${pkgVersion},5.3)",
+            org.springframework.util.function;version="[${pkgVersion},5.3)",
             org.springframework.util.xml;version="[${pkgVersion},5.3)",
             org.w3c.dom,
             org.w3c.dom.ls,


### PR DESCRIPTION
XStreamMarshaller uses the class SingletonSupplier from org.springframework.util.function [here](https://github.com/spring-projects/spring-framework/blob/v5.2.8.RELEASE/spring-oxm/src/main/java/org/springframework/oxm/xstream/XStreamMarshaller.java#L87).