### PR TITLE
fix spring-security oauth2 bundles

### DIFF
--- a/spring-security-oauth2-client-5.3.3.RELEASE/pom.xml
+++ b/spring-security-oauth2-client-5.3.3.RELEASE/pom.xml
@@ -46,10 +46,11 @@
         <pkgArtifactId>spring-security-oauth2-client</pkgArtifactId>
         <pkgVersion>5.3.3.RELEASE</pkgVersion>
         <servicemix.osgi.export.pkg>
-            org.springframework.security.oauth2.client
+            org.springframework.security.oauth2.client*
         </servicemix.osgi.export.pkg>
         <servicemix.osgi.import.pkg>
             com.nimbusds*;resolution:=optional,
+            org.springframework.security.oauth2.core,
             *
         </servicemix.osgi.import.pkg>
     </properties>

--- a/spring-security-oauth2-core-5.3.3.RELEASE/pom.xml
+++ b/spring-security-oauth2-core-5.3.3.RELEASE/pom.xml
@@ -46,10 +46,12 @@
         <pkgArtifactId>spring-security-oauth2-core</pkgArtifactId>
         <pkgVersion>5.3.3.RELEASE</pkgVersion>
         <servicemix.osgi.export.pkg>
-            org.springframework.security.oauth2.core
+            org.springframework.security.oauth2.core*
         </servicemix.osgi.export.pkg>
         <servicemix.osgi.import.pkg>
             com.nimbusds*;resolution:=optional,
+            com.fasterxml.jackson.databind;resolution:=optional,
+            com.fasterxml.jackson.core;resolution:=optional,
             *
         </servicemix.osgi.import.pkg>
     </properties>

--- a/spring-security-oauth2-jose-5.3.3.RELEASE/pom.xml
+++ b/spring-security-oauth2-jose-5.3.3.RELEASE/pom.xml
@@ -49,6 +49,7 @@
             org.springframework.security.oauth2.j*
         </servicemix.osgi.export.pkg>
         <servicemix.osgi.import.pkg>
+            com.nimbusds.oauth2.sdk;resolution:=optional,
             com.nimbusds*;resolution:=optional,
             *
         </servicemix.osgi.import.pkg>

--- a/spring-security-oauth2-jose-5.3.3.RELEASE/pom.xml
+++ b/spring-security-oauth2-jose-5.3.3.RELEASE/pom.xml
@@ -46,7 +46,7 @@
         <pkgArtifactId>spring-security-oauth2-jose</pkgArtifactId>
         <pkgVersion>5.3.3.RELEASE</pkgVersion>
         <servicemix.osgi.export.pkg>
-            org.springframework.security.oauth2.jose
+            org.springframework.security.oauth2.j*
         </servicemix.osgi.export.pkg>
         <servicemix.osgi.import.pkg>
             com.nimbusds*;resolution:=optional,


### PR DESCRIPTION
Hello,

I tested spring-security oauth2 in a osgi blueprint/spring application configured using spring security dsl <http> like described in Example 94 https://docs.spring.io/spring-security/site/docs/current/reference/html5/#oauth2login-advanced.

I needed to fix various bundle metadata, and jose jar was missing packages.
Here the pull request with my fixes.