### PR TITLE
Fix castor-1.4.1 package imports

### DIFF
--- a/castor-1.4.1/pom.xml
+++ b/castor-1.4.1/pom.xml
@@ -57,6 +57,7 @@
             org.w3c.dom,
             org.xml.sax*,
             org.apache.commons.lang;version="[2.1,3)",
+            org.apache.commons.lang3;version="[3.4,4)",
             org.apache.oro*;version="[2,3)",
             org.apache.regexp*;version="[1.4,2)",
             org.springframework.stereotype;resolution:=optional,


### PR DESCRIPTION
The current castor bundle surprises me with the following exception: `java.lang.ClassNotFoundException: org.apache.commons.lang3.StringUtils cannot be found by org.apache.servicemix.bundles.castor_1.4.1.1` at `AbstractProperties.java` line 661. This is due to a missing package import of `org.apache.commons.lang3`. Here's a fix.