### PR TITLE
SQLErrorCodeSQLExceptionTranslator broken because of missing package import

### DIFF
--- a/spring-jdbc-5.2.9.RELEASE/pom.xml
+++ b/spring-jdbc-5.2.9.RELEASE/pom.xml
@@ -84,6 +84,7 @@
             org.springframework.transaction;version="[${pkgVersion},5.3)",
             org.springframework.transaction.support;version="[${pkgVersion},5.3)",
             org.springframework.util;version="[${pkgVersion},5.3)",
+            org.springframework.util.function;version="[${pkgVersion},5.3)",
             org.springframework.util.xml;version="[${pkgVersion},5.3)",
             org.w3c.dom;resolution:=optional,
             weblogic.jdbc.extensions;resolution:=optional


### PR DESCRIPTION
SQLErrorCodeSQLExceptionTranslator uses the classes SingletonSupplier and SupplierUtils from this package [here](https://github.com/spring-projects/spring-framework/blob/v5.2.9.RELEASE/spring-jdbc/src/main/java/org/springframework/jdbc/support/SQLErrorCodeSQLExceptionTranslator.java#L38).