### PR TITLE
Add missing metrics package import to spring-context-5.3.0.

### DIFF
--- a/spring-context-5.3.0/pom.xml
+++ b/spring-context-5.3.0/pom.xml
@@ -135,6 +135,7 @@
             org.springframework.core.env;version="[${pkgVersion},5.4)",
             org.springframework.core.io;version="[${pkgVersion},5.4)",
             org.springframework.core.io.support;version="[${pkgVersion},5.4)",
+            org.springframework.core.metrics;version="[${pkgVersion},5.4)",
             org.springframework.core.serializer.support;version="[${pkgVersion},5.4)";resolution:=optional,
             org.springframework.core.task;version="[${pkgVersion},5.4)",
             org.springframework.core.task.support;version="[${pkgVersion},5.4)",


### PR DESCRIPTION
This package is referenced by [AbstractApplicationContext](https://github.com/spring-projects/spring-framework/blob/v5.3.0/spring-context/src/main/java/org/springframework/context/support/AbstractApplicationContext.java#L81) among others.