### PR TITLE
fix spring-security oauth2-jose

### DIFF
--- a/spring-security-oauth2-jose-5.4.1/pom.xml
+++ b/spring-security-oauth2-jose-5.4.1/pom.xml
@@ -50,6 +50,7 @@
         </servicemix.osgi.export.pkg>
         <servicemix.osgi.import.pkg>
             com.nimbusds.oauth2.sdk;resolution:=optional,
+            com.nimbusds.jose;resolution:=optional,
             com.nimbusds*;resolution:=optional,
             *
         </servicemix.osgi.import.pkg>


### PR DESCRIPTION
Switching to latest spring security, we were facing a ClassNotFoundException for com.nimbusds.jose.RemoteKeySourceException
This PR is a proposed fix for that issue.

