### PR TITLE
pulsar-client - add io.airlift.compress as import

### DIFF
--- a/pulsar-client-2.7.0/pom.xml
+++ b/pulsar-client-2.7.0/pom.xml
@@ -58,7 +58,8 @@
             org.slf4j,
             javax.naming,javax.net.ssl,
             net.jpountz.lz4,
-            org.w3c.dom
+	    org.w3c.dom,
+	    io.airlift.compress.*
         </servicemix.osgi.import.pkg>
     </properties>
 

--- a/pulsar-client-2.7.0/pom.xml
+++ b/pulsar-client-2.7.0/pom.xml
@@ -58,8 +58,8 @@
             org.slf4j,
             javax.naming,javax.net.ssl,
             net.jpountz.lz4,
-	    org.w3c.dom,
-	    io.airlift.compress.*
+            org.w3c.dom,
+            io.airlift.compress.*
         </servicemix.osgi.import.pkg>
     </properties>
 


### PR DESCRIPTION
The servicemix for pulsar client is failing to initialize because of missing import of new compression library.