### PR TITLE
Add missing org.apache.axiom.mime import to spring-ws-core.

### DIFF
--- a/spring-ws-core-3.0.10.RELEASE/pom.xml
+++ b/spring-ws-core-3.0.10.RELEASE/pom.xml
@@ -77,6 +77,7 @@
             nu.xom;resolution:=optional, 
             nu.xom.converters;resolution:=optional, 
             org.apache.axiom.attachments;resolution:=optional, 
+            org.apache.axiom.mime;resolution:=optional, 
             org.apache.axiom.om;resolution:=optional, 
             org.apache.axiom.om.ds;resolution:=optional, 
             org.apache.axiom.om.impl;resolution:=optional, 


### PR DESCRIPTION
Using org.springframework.ws.transport.jms.WebServiceMessageListener
with an AxiomSoapMessageFactory will result in a
java.lang.NoClassDefFoundError.

```
2021-02-02 16:06:28,022 [ws-jms-1] WARN  org.springframework.jms.listener.DefaultMessageListenerContainer - Execution of JMS message listener failed, and no ErrorHandler has been set.
java.lang.NoClassDefFoundError: org/apache/axiom/mime/MediaType
        at org.springframework.ws.soap.axiom.AxiomSoapMessageFactory.createWebServiceMessage(AxiomSoapMessageFactory.java:235)
        at org.springframework.ws.soap.axiom.AxiomSoapMessageFactory.createWebServiceMessage(AxiomSoapMessageFactory.java:85)
        at org.springframework.ws.transport.AbstractWebServiceConnection.receive(AbstractWebServiceConnection.java:92)
        at org.springframework.ws.transport.support.WebServiceMessageReceiverObjectSupport.handleConnection(WebServiceMessageReceiverObjectSupport.java:87)
        at org.springframework.ws.transport.support.SimpleWebServiceMessageReceiverObjectSupport.handleConnection(SimpleWebServiceMessageReceiverObjectSupport.java:57)
        at org.springframework.ws.transport.jms.JmsMessageReceiver.handleMessage(JmsMessageReceiver.java:82)
        at org.springframework.ws.transport.jms.WebServiceMessageListener.onMessage(WebServiceMessageListener.java:46)
[...]
Caused by: java.lang.ClassNotFoundException: org.apache.axiom.mime.MediaType not found by org.apache.servicemix.bundles.spring-ws-core [105]
        at org.apache.felix.framework.BundleWiringImpl.findClassOrResourceByDelegation(BundleWiringImpl.java:1597)
        at org.apache.felix.framework.BundleWiringImpl.access$300(BundleWiringImpl.java:79)
        at org.apache.felix.framework.BundleWiringImpl$BundleClassLoader.loadClass(BundleWiringImpl.java:1982)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:413)
        ... 41 common frames omitted
```