### PR TITLE
fix spring-ldap missing export

### DIFF
--- a/spring-ldap-2.3.3.RELEASE/pom.xml
+++ b/spring-ldap-2.3.3.RELEASE/pom.xml
@@ -46,6 +46,7 @@
         <pkgGroupId>org.springframework.ldap</pkgGroupId>
         <pkgVersion>2.3.3.RELEASE</pkgVersion>
         <servicemix.osgi.export.pkg>
+            org.springframework;-split-package:=merge-first,
             org.springframework.ldap
         </servicemix.osgi.export.pkg>
         <servicemix.osgi.import.pkg>


### PR DESCRIPTION
 org.springframework.LdapDataEntry is part of public spring ldap api, so spring-ldap should export org.springframework package otherwise it could lead to some access restriction 