### PR TITLE
Add missing spring util.xml import to spring-batch-infrastructure.

### DIFF
--- a/spring-batch-infrastructure-4.3.2/pom.xml
+++ b/spring-batch-infrastructure-4.3.2/pom.xml
@@ -114,6 +114,7 @@
             org.springframework.transaction;resolution:=optional, 
             org.springframework.transaction.support;resolution:=optional, 
             org.springframework.util;resolution:=optional, 
+            org.springframework.util.xml;resolution:=optional, 
             org.springframework.validation;resolution:=optional
         </servicemix.osgi.import.pkg>
     </properties>


### PR DESCRIPTION
The StaxEvent classes in spring-batch require StaxUtils which is in this
package.

Example:

https://github.com/spring-projects/spring-batch/blob/4.3.2/spring-batch-infrastructure/src/main/java/org/springframework/batch/item/xml/StaxEventItemReader.java#L48

```
Caused by: java.lang.ClassNotFoundException: org.springframework.util.xml.StaxUtils not found by org.apache.servicemix.bundles.spring-batch-infrastructure [90]
        at org.apache.felix.framework.BundleWiringImpl.findClassOrResourceByDelegation(BundleWiringImpl.java:1597)
        at org.apache.felix.framework.BundleWiringImpl.access$300(BundleWiringImpl.java:79)
        at org.apache.felix.framework.BundleWiringImpl$BundleClassLoader.loadClass(BundleWiringImpl.java:1982)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:413)
        ... 518 common frames omitted
```