### PR TITLE
set kotlinx dependences as optional

### DIFF
--- a/spring-security-core-5.5.0/pom.xml
+++ b/spring-security-core-5.5.0/pom.xml
@@ -55,7 +55,8 @@
 			org.reactivestreams;resolution:="optional",
 			reactor.*;resolution:="optional",
 			org.springframework.jdbc.*;resolution:="optional",
-            *
+			kotlinx.coroutines.*;resolution:="optional",
+			*
         </servicemix.osgi.import.pkg>
     </properties>
 


### PR DESCRIPTION
I noticed spring-security-core import kotlinx packages as mandatory. It seems wrong to me, these dependences needs to be set as optional 