### PR TITLE
[SM-4934] Import optional netty package in spring-core

### DIFF
--- a/spring-core-5.3.12/pom.xml
+++ b/spring-core-5.3.12/pom.xml
@@ -49,6 +49,7 @@
             org.springframework
         </servicemix.osgi.export.pkg>
         <servicemix.osgi.import.pkg>
+            io.netty.buffer;resolution:=optional,
             javax.net;resolution:=optional,
             javax.xml;resolution:=optional,
             javax.xml.bind;resolution:=optional,


### PR DESCRIPTION
This is required by classes such as NettyDataBufferFactory.