### PR TITLE
Add missing dependency on com.thoughtworks.xstream.security to spring-oxm.

### DIFF
--- a/spring-oxm-5.3.13/pom.xml
+++ b/spring-oxm-5.3.13/pom.xml
@@ -58,6 +58,7 @@
             com.thoughtworks.xstream.io.naming;version="[1.4,2)";resolution:=optional,
             com.thoughtworks.xstream.io.xml;version="[1.4,2)";resolution:=optional,
             com.thoughtworks.xstream.mapper;version="[1.4,2)";resolution:=optional,
+            com.thoughtworks.xstream.security;version="[1.4,2)";resolution:=optional,
             javax.activation;resolution:=optional,
             javax.xml;resolution:=optional,
             javax.xml.bind;resolution:=optional,


### PR DESCRIPTION
Spring OXM's XStreamMarshaller references this package here:

https://github.com/spring-projects/spring-framework/blob/v5.3.13/spring-oxm/src/main/java/org/springframework/oxm/xstream/XStreamMarshaller.java#L66

```
Caused by: java.lang.ClassNotFoundException: com.thoughtworks.xstream.security.TypePermission not found by org.apache.servicemix.bundles.spring-oxm [99]
        at org.apache.felix.framework.BundleWiringImpl.findClassOrResourceByDelegation(BundleWiringImpl.java:1597)
        at org.apache.felix.framework.BundleWiringImpl.access$300(BundleWiringImpl.java:79)
        at org.apache.felix.framework.BundleWiringImpl$BundleClassLoader.loadClass(BundleWiringImpl.java:1982)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:413)
        ... 71 common frames omitted
```