### PR TITLE
[SM-5143] Remove package/capability headers from source bundles

### DIFF
--- a/bundles-pom/pom.xml
+++ b/bundles-pom/pom.xml
@@ -102,7 +102,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <version>3.0.0</version>
+                    <version>3.3.0</version>
                     <executions>
                         <execution>
                             <id>sources</id>
@@ -130,6 +130,10 @@
                                         <manifestEntries>
                                             <Bundle-SymbolicName>${project.artifactId}.source</Bundle-SymbolicName>
                                             <Eclipse-SourceBundle>${project.artifactId};version="${project.version}"</Eclipse-SourceBundle>
+                                            <Export-Package></Export-Package>
+                                            <Import-Package></Import-Package>
+                                            <Provide-Capability></Provide-Capability>
+                                            <Require-Capability></Require-Capability>
                                         </manifestEntries>
                                     </transformer>
                                 </transformers>


### PR DESCRIPTION
With Shade plugin version 3.3.0 setting these as empty elements
causes the headers to be excluded from the manifest.

These four are included by default with the ManifestResourceTransformer
as documented at:
https://maven.apache.org/plugins/maven-shade-plugin/examples/resource-transformers.html

Their presence can cause issues resolving bundles, particularly in
Eclipse, as the source bundle is resolved instead of the classes bundle.
See also JIRA SM-2654.