### PR TITLE
[SM-5254] Create OSGi bundle for google-gax-grpc 2.18.1

### DIFF
--- a/google-gax-grpc-2.18.1/pom.xml
+++ b/google-gax-grpc-2.18.1/pom.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <!--
+
+        Licensed to the Apache Software Foundation (ASF) under one or more
+        contributor license agreements.  See the NOTICE file distributed with
+        this work for additional information regarding copyright ownership.
+        The ASF licenses this file to You under the Apache License, Version 2.0
+        (the "License"); you may not use this file except in compliance with
+        the License.  You may obtain a copy of the License at
+
+           http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+    -->
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.servicemix.bundles</groupId>
+        <artifactId>bundles-pom</artifactId>
+        <version>15</version>
+        <relativePath>../bundles-pom/pom.xml</relativePath>
+    </parent>
+
+    <groupId>org.apache.servicemix.bundles</groupId>
+    <artifactId>org.apache.servicemix.bundles.google-gax-grpc</artifactId>
+    <version>2.18.1_1-SNAPSHOT</version>
+    <packaging>bundle</packaging>
+    <name>Apache ServiceMix :: Bundles :: Google Gax GRPC</name>
+    <description>This OSGi bundle wraps ${pkgArtifactId} ${pkgVersion} jar files.</description>
+
+    <scm>
+        <connection>scm:git:https://gitbox.apache.org/repos/asf/servicemix-bundles.git</connection>
+        <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/servicemix-bundles.git</developerConnection>
+        <url>https://gitbox.apache.org/repos/asf?p=servicemix-bundles.git</url>
+    <tag>HEAD</tag>
+  </scm>
+
+    <properties>
+        <pkgGroupId>com.google.api</pkgGroupId>
+        <pkgArtifactId>gax-grpc</pkgArtifactId>
+        <pkgVersion>2.18.1</pkgVersion>
+        <servicemix.osgi.source.version>2.18.1</servicemix.osgi.source.version>
+        <servicemix.osgi.export.pkg>
+           com.google.api.gax*
+        </servicemix.osgi.export.pkg>
+        <servicemix.osgi.import.pkg>
+           !com.google.appengine*,
+           !com.google.apphosting*,
+           !com.google.longrunning*,
+           !com.google.rpc*,
+           !javax.annotation*,
+           !org.checkerframework*,
+           org.graalvm*;resolution:=optional,
+           *
+        </servicemix.osgi.import.pkg>
+        <servicemix.osgi.private.pkg>
+           com.google.appengine*,
+           com.google.apphosting*,
+           com.google.longrunning*,
+           com.google.rpc*,
+           javax.annotation*,
+           org.checkerframework*
+        </servicemix.osgi.private.pkg>        
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${pkgGroupId}</groupId>
+            <artifactId>${pkgArtifactId}</artifactId>
+            <version>${pkgVersion}</version>
+        </dependency>
+
+        <!-- sources -->
+        <dependency>
+            <groupId>${pkgGroupId}</groupId>
+            <artifactId>${pkgArtifactId}</artifactId>
+            <version>${pkgVersion}</version>
+            <classifier>sources</classifier>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>${pkgGroupId}:${pkgArtifactId}</include>
+                                </includes>
+                            </artifactSet>
+                            <filters>
+                                <filter>
+                                    <artifact>${pkgGroupId}:${pkgArtifactId}</artifact>
+                                    <excludes>
+                                        <exclude>**/*</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/google-gax-grpc-2.18.1/src/main/resources/OSGI-INF/bundle.info
+++ b/google-gax-grpc-2.18.1/src/main/resources/OSGI-INF/bundle.info
@@ -1,0 +1,12 @@
+\u001B[1mSYNOPSIS\u001B[0m
+    ${project.description}
+
+    Original Maven URL:
+        \u001B[33mmvn:${pkgGroupId}/${pkgArtifactId}/${pkgVersion}\u001B[0m
+
+\u001B[1mDESCRIPTION\u001B[0m
+    Google API Extensions for Java (GAX Java) is a library which aids in the development of client libraries for server
+    APIs, based on GRPC and Google API conventions.
+
+\u001B[1mSEE ALSO\u001B[0m
+    \u001B[36mhttps://github.com/googleapis/gax-java\u001B[0m

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,7 @@
       <module>hapi-fhir-validation-6.0.4</module>
       <module>azure-identity-1.5.3</module>
       <module>esapi-2.5.0.0</module>
+      <module>google-gax-grpc-2.18.1</module>
       <module>google-http-client-1.42.2</module>
       <module>azure-messaging-eventhubs-checkpointstore-blob-1.14.0</module>
       <module>grpc-1.48.0</module>


### PR DESCRIPTION
Fix for https://issues.apache.org/jira/browse/SM-5254

## Motivation

In order to have camel-google-pubsub back into camel-karaf, I would need to add a new OSGi bundle for google-gax-grpc 2.18.1. (https://issues.apache.org/jira/browse/CAMEL-18344)

## Modifications:

* Add the new module in the parent pom
* Add a bundle.info to describe shortly the new bundle
* Add a new pom file for the new bundle