### PR TITLE
[SM-5256] Improve flexibility of google-http-client 1.41.8

### DIFF
--- a/google-http-client-1.41.8/pom.xml
+++ b/google-http-client-1.41.8/pom.xml
@@ -53,7 +53,12 @@
 		com.google.api.client.util*;version="1.41.8"
         </servicemix.osgi.export>
         <servicemix.osgi.import.pkg>
+        com.google.common*;version="30.1",
+        *
         </servicemix.osgi.import.pkg>
+        <servicemix.osgi.private.pkg>
+           javax.annotation*
+        </servicemix.osgi.private.pkg>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Fix for https://issues.apache.org/jira/browse/SM-5256

## Motivation

While using the bundle google-http-client 1.41.8 for https://issues.apache.org/jira/browse/CAMEL-18344, I realized that it could be improved a little bit more to ease its integration

## Modifications:

* Include javax.annotation like many other bundles
* Open the version needed for google guava to allow more recent versions which are still compatible