### PR TITLE
Fix OkHttp 4.10.0 bundle import

### DIFF
--- a/okhttp-4.10.0/pom.xml
+++ b/okhttp-4.10.0/pom.xml
@@ -51,10 +51,10 @@
             okhttp3
         </servicemix.osgi.export.pkg>
         <servicemix.osgi.import.pkg>
-            okio;version="[1.11.0,3)",
+            okio;version="[3.0.0,4)",
             org.apache.http.*;resolution:=optional,
-	          org.bouncycastle.*;resolution:=optional,
-	          org.openjsse.*;resolution:=optional,
+            org.bouncycastle.*;resolution:=optional,
+            org.openjsse.*;resolution:=optional,
             android.net.*;resolution:=optional,
             android.os.*;resolution:=optional,
             android.security.*;resolution:=optional,


### PR DESCRIPTION
As `okio-jvm` exports version 3.0.0.