### PR TITLE
[SM-5414] Create OSGi bundle for elasticsearch-java 8.5.2

### DIFF
--- a/elasticsearch-java-8.5.2/pom.xml
+++ b/elasticsearch-java-8.5.2/pom.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <!--
+
+        Licensed to the Apache Software Foundation (ASF) under one or more
+        contributor license agreements.  See the NOTICE file distributed with
+        this work for additional information regarding copyright ownership.
+        The ASF licenses this file to You under the Apache License, Version 2.0
+        (the "License"); you may not use this file except in compliance with
+        the License.  You may obtain a copy of the License at
+
+           http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+    -->
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.servicemix.bundles</groupId>
+        <artifactId>bundles-pom</artifactId>
+        <version>15</version>
+        <relativePath>../bundles-pom/pom.xml</relativePath>
+    </parent>
+
+    <groupId>org.apache.servicemix.bundles</groupId>
+    <artifactId>org.apache.servicemix.bundles.elasticsearch-java</artifactId>
+    <version>8.5.2_1-SNAPSHOT</version>
+    <packaging>bundle</packaging>
+    <name>Apache ServiceMix :: Bundles :: Elasticsearch Java Client</name>
+    <description>This OSGi bundle wraps ${pkgArtifactId} ${pkgVersion} jar files.</description>
+
+    <scm>
+        <connection>scm:git:https://gitbox.apache.org/repos/asf/servicemix-bundles.git</connection>
+        <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/servicemix-bundles.git</developerConnection>
+        <url>https://gitbox.apache.org/repos/asf?p=servicemix-bundles.git</url>
+    <tag>HEAD</tag>
+  </scm>
+
+    <properties>
+        <pkgGroupId>co.elastic.clients</pkgGroupId>
+        <pkgArtifactId>elasticsearch-java</pkgArtifactId>
+        <pkgVersion>8.5.2</pkgVersion>
+        <servicemix.osgi.source.version>8.5.2.1</servicemix.osgi.source.version>
+        <servicemix.osgi.export.pkg>
+           co.elastic.clients*,
+           org.elasticsearch.client*
+        </servicemix.osgi.export.pkg>
+        <servicemix.osgi.import.pkg>
+           !org.elasticsearch.client*,
+           !javax.annotation*,
+           jakarta.json.bind*;resolution:=optional,
+           com.fasterxml.jackson*;resolution:=optional,
+           *
+        </servicemix.osgi.import.pkg>
+        <servicemix.osgi.private.pkg>
+           org.elasticsearch.client*,
+           javax.annotation*
+        </servicemix.osgi.private.pkg>        
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${pkgGroupId}</groupId>
+            <artifactId>${pkgArtifactId}</artifactId>
+            <version>${pkgVersion}</version>
+        </dependency>
+
+        <!-- sources -->
+        <dependency>
+            <groupId>${pkgGroupId}</groupId>
+            <artifactId>${pkgArtifactId}</artifactId>
+            <version>${pkgVersion}</version>
+            <classifier>sources</classifier>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>${pkgGroupId}:${pkgArtifactId}</include>
+                                </includes>
+                            </artifactSet>
+                            <filters>
+                                <filter>
+                                    <artifact>${pkgGroupId}:${pkgArtifactId}</artifact>
+                                    <excludes>
+                                        <exclude>**/*</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/elasticsearch-java-8.5.2/src/main/resources/OSGI-INF/bundle.info
+++ b/elasticsearch-java-8.5.2/src/main/resources/OSGI-INF/bundle.info
@@ -1,0 +1,14 @@
+\u001B[1mSYNOPSIS\u001B[0m
+    ${project.description}
+
+    Original Maven URL:
+        \u001B[33mmvn:${pkgGroupId}/${pkgArtifactId}/${pkgVersion}\u001B[0m
+
+\u001B[1mDESCRIPTION\u001B[0m
+    The Java client for Elasticsearch provides strongly typed requests and responses for all Elasticsearch
+    APIs. It delegates protocol handling to an http client such as the Elasticsearch Low Level REST client
+    that takes care of all transport-level concerns (http connection establishment and pooling, retries,
+    etc).
+
+\u001B[1mSEE ALSO\u001B[0m
+    \u001B[36mhttps://github.com/elastic/elasticsearch-java\u001B[0m


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SM-5414

## Motivation

A new client for elastic search is available with an Apache License 2.0 but the jar is not OSGI compatible

## Modifications

* Add a new module for elasticsearch-java 8.5.2