### PR TITLE
Fix issue related to mandatory dependency in OkHttp bundle

### DIFF
--- a/okhttp-4.10.0/pom.xml
+++ b/okhttp-4.10.0/pom.xml
@@ -59,6 +59,7 @@
             android.security.*;resolution:=optional,
             android.util.*;resolution:=optional,
             org.conscrypt.*;resolution:=optional,
+            dalvik.system.*;resolution:=optional,
             *
         </servicemix.osgi.import.pkg>
     </properties>

--- a/okhttp-4.10.0/pom.xml
+++ b/okhttp-4.10.0/pom.xml
@@ -52,7 +52,6 @@
         </servicemix.osgi.export.pkg>
         <servicemix.osgi.import.pkg>
             okio;version="[3.0.0,4)",
-            org.apache.http.*;resolution:=optional,
             org.bouncycastle.*;resolution:=optional,
             org.openjsse.*;resolution:=optional,
             android.net.*;resolution:=optional,
@@ -133,7 +132,6 @@
                                 <includes>
                                     <include>${pkgGroupId}:okhttp</include>
                                     <include>${pkgGroupId}:okhttp-urlconnection</include>
-                                    <include>${pkgGroupId}:okhttp-apache</include>
                                     <include>${pkgGroupId}:logging-interceptor</include>
                                 </includes>
                             </artifactSet>
@@ -146,12 +144,6 @@
                                 </filter>
                                 <filter>
                                     <artifact>${pkgGroupId}:okhttp-urlconnection</artifact>
-                                    <excludes>
-                                        <exclude>**</exclude>
-                                    </excludes>
-                                </filter>
-                                <filter>
-                                    <artifact>${pkgGroupId}:okhttp-apache</artifact>
                                     <excludes>
                                         <exclude>**</exclude>
                                     </excludes>


### PR DESCRIPTION
When trying to use `org.apache.servicemix.bundles:org.apache.servicemix.bundles.okhttp:4.10.0_2`, I'm running into the issue of `dalvik.system.*` being required.
For the record, out of `MANIFEST.MF`:
```
Import-Package:
okio;version="[3.0.0,4)",
org.bouncycastle.jsse;resolution:=optional,
org.bouncycastle.jsse.provider;resolution:=optional,
org.openjsse.javax.net.ssl;resolution:=optional,
org.openjsse.net.ssl;resolution:=optional,
android.net.http;resolution:=optional,
android.net.ssl;resolution:=optional,
android.os;resolution:=optional,
android.security;resolution:=optional,
android.util;resolution:=optional,
org.conscrypt;resolution:=optional,
dalvik.system,
javax.net,
javax.net.ssl,
javax.security.auth.x500,
kotlin,
kotlin.annotation,
kotlin.collections,
kotlin.comparisons,
kotlin.internal,
kotlin.io,
kotlin.jvm,
kotlin.jvm.functions,
kotlin.jvm.internal,
kotlin.jvm.internal.markers,
kotlin.ranges,
kotlin.sequences,
kotlin.text,
okhttp3;version="[4.10,5)",
okhttp3.internal;version="[4.10,5)",
okhttp3.internal.authenticator;version="[4.10,5)",
okhttp3.internal.cache;version="[4.10,5)",
okhttp3.internal.concurrent;version="[4.10,5)",
okhttp3.internal.connection;version="[4.10,5)",
okhttp3.internal.http;version="[4.10,5)",
okhttp3.internal.http1;version="[4.10,5)",
okhttp3.internal.http2;version="[4.10,5)",
okhttp3.internal.io;version="[4.10,5)",
okhttp3.internal.platform;version="[4.10,5)",
okhttp3.internal.platform.android;version="[4.10,5)",
okhttp3.internal.proxy;version="[4.10,5)",
okhttp3.internal.publicsuffix;version="[4.10,5)",
okhttp3.internal.tls;version="[4.10,5)",
okhttp3.internal.ws;version="[4.10,5)",
sun.security.ssl
```

I suggest to mark `dalvik.system` as optional.