### PR TITLE
Adding elasticsearch 7.17.8 libs to provide compatibilty/access from …

### DIFF
--- a/elasticsearch-7.17.8/pom.xml
+++ b/elasticsearch-7.17.8/pom.xml
@@ -1,0 +1,213 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <!--
+
+        Licensed to the Apache Software Foundation (ASF) under one or more
+        contributor license agreements.  See the NOTICE file distributed with
+        this work for additional information regarding copyright ownership.
+        The ASF licenses this file to You under the Apache License, Version 2.0
+        (the "License"); you may not use this file except in compliance with
+        the License.  You may obtain a copy of the License at
+
+           http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+    -->
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.servicemix.bundles</groupId>
+        <artifactId>bundles-pom</artifactId>
+        <version>14</version>
+        <relativePath>../bundles-pom/pom.xml</relativePath>
+    </parent>
+
+    <groupId>org.apache.servicemix.bundles</groupId>
+    <artifactId>org.apache.servicemix.bundles.elasticsearch</artifactId>
+    <version>7.17.8</version>
+    <packaging>bundle</packaging>
+    <name>Apache ServiceMix :: Bundles :: ${pkgArtifactId}</name>
+    <description>This OSGi bundle wraps ${pkgArtifactId} ${pkgVersion} jar file.</description>
+
+    <scm>
+        <connection>scm:git:https://gitbox.apache.org/repos/asf/servicemix-bundles.git</connection>
+        <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/servicemix-bundles.git</developerConnection>
+        <url>https://gitbox.apache.org/repos/asf?p=servicemix-bundles.git</url>
+    <tag>HEAD</tag>
+  </scm>
+
+    <properties>
+        <pkgGroupId>org.elasticsearch</pkgGroupId>
+        <pkgArtifactId>elasticsearch</pkgArtifactId>
+        <pkgVersion>7.17.8</pkgVersion>
+        <servicemix.osgi.export>
+            org.elasticsearch*;version="${pkgVersion}";-split-package:=merge-first,
+           org.apache.lucene.search,
+           com.github.mustachejava*;
+        </servicemix.osgi.export>
+        <servicemix.osgi.import.pkg>
+            !org.elasticsearch*,
+            !org.joda.time,
+            !org.joda.convert,
+            !org.noggit,
+            !org.locationtech.spatial4j*,
+            !com.vividsolutions.jts.geom,
+            !org.apache.lucene*,
+            !com.carrotsearch.randomizedtesting,
+            !com.github.mustachejava*,
+            com.google.common.collect;resolution:=optional,
+            com.google.common.geometry;resolution:=optional,
+            com.fasterxml.jackson.core;version="[2.8,4)",
+            com.fasterxml.jackson.dataformat.yaml;version="[2.8,4)",
+            com.fasterxml.jackson.dataformat.smile;version="[2.8,4)",
+            com.sun.jna*;resolution:=optional,
+            com.sun.management;resolution:=optional,
+            com.ning.compress.lzf.util,
+            org.apache.logging.log4j*;version="[2.8,4)",
+            org.locationtech.jts.geom;resolution:=optional,
+            *
+        </servicemix.osgi.import.pkg>
+        <servicemix.osgi.private.pkg>
+            org.joda.time*;-split-package:=merge-first,
+            org.joda.convert*,
+            org.noggit,
+            org.apache.lucene*;-split-package:=merge-first,
+            org.tartarus.snowball*,
+            com.tdunning.math.stats,
+            com.vividsolutions.jts.geom,
+            com.carrotsearch.hppc*,
+            com.carrotsearch.randomizedtesting,
+            joptsimple*,
+            org.HdrHistogram,
+            org.locationtech.spatial4j*,
+            !META-INF.services.org.apache.lucene.codecs.Codec,
+            META-INF.services.*;-split-package:=merge-first
+        </servicemix.osgi.private.pkg>
+    </properties>
+
+    <dependencies>
+    <dependency>
+            <groupId>org.elasticsearch.client</groupId>
+            <artifactId>elasticsearch-rest-client</artifactId>
+            <version>${pkgVersion}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.elasticsearch.client</groupId>
+            <artifactId>elasticsearch-rest-client-sniffer</artifactId>
+            <version>${pkgVersion}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.elasticsearch.client</groupId>
+            <artifactId>elasticsearch-rest-high-level-client</artifactId>
+            <version>${pkgVersion}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.elasticsearch.client</groupId>
+            <artifactId>transport</artifactId>
+            <version>${pkgVersion}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>${pkgGroupId}</groupId>
+            <artifactId>${pkgArtifactId}</artifactId>
+            <version>${pkgVersion}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.elasticsearch.plugin</groupId>
+            <artifactId>transport-netty4-client</artifactId>
+            <version>${pkgVersion}</version>
+        </dependency>
+        <dependency>
+             <groupId>org.apache.logging.log4j</groupId>
+             <artifactId>log4j-core</artifactId>
+             <version>2.11.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-backward-codecs</artifactId>
+            <version>8.5.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.spullara.mustache.java</groupId>
+            <artifactId>compiler</artifactId>
+            <version>0.9.10</version>
+        </dependency>
+
+
+        <!-- sources -->
+        <dependency>
+            <groupId>${pkgGroupId}</groupId>
+            <artifactId>${pkgArtifactId}</artifactId>
+            <version>${pkgVersion}</version>
+            <classifier>sources</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.elasticsearch.plugin</groupId>
+            <artifactId>transport-netty4-client</artifactId>
+            <version>${pkgVersion}</version>
+            <classifier>sources</classifier>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>${pkgGroupId}:${pkgArtifactId}</include>
+				    <include>org.elasticsearch.plugin:transport-netty4client</include>
+                                    <include>org.apache.lucene:*</include>
+                                </includes>
+                            </artifactSet>
+                            <filters>
+                                <filter>
+                                    <artifact>${pkgGroupId}:${pkgArtifactId}</artifact>
+                                    <includes>
+                                        <include>config/**</include>
+                                        <include>META-INF/services/**</include>
+                                        <include>plugins.txt</include>
+                                    </includes>
+                                </filter>
+                                <filter>
+                                    <artifact>org.apache.lucene:*</artifact>
+                                    <includes>
+                                        <include>META-INF/services/**</include>
+                                    </includes>
+                                </filter>
+                            </filters>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                            </transformers>
+                            <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+                            <createDependencyReducedPom>true</createDependencyReducedPom>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-compiler-plugin</artifactId>
+              <configuration>
+                <source>1.8</source>
+                <target>1.8</target>
+              </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
Adding support for Elasticsearch 7.17.8 libs, for communication/compatibility with Elasticsearch 8.x application versions.

Intent is to provide the osgi version of 7.17.8 libraries which is compatible to communicate with ES 8.x app versions.  This will provide support for the users/applications which are still on java 8 or in the initial phase of migration to higher ES application versions.