### PR TITLE
Fix solrj 9.1.1 bundle import

### DIFF
--- a/solr-solrj-9.1.1/pom.xml
+++ b/solr-solrj-9.1.1/pom.xml
@@ -62,6 +62,7 @@
             org.apache.http*,
             org.apache.noggit;resolution:=optional,
             org.apache.zookeeper*;resolution:=optional,
+            org.eclipse.jetty*;resolution:=optional,
             org.noggit;resolution:=optional,
             org.slf4j;resolution:=optional
         </servicemix.osgi.import.pkg>


### PR DESCRIPTION
Solr import org.eclipse.jetty

```
$ java -jar biz.aQute.bnd-6.3.1.jar xref --to --destination 'org.eclipse.jetty*' ~/.m2/repository/org/apache/solr/solr-solrj/9.1.1/solr-solrj-9.1.1.jar
             org.apache.solr.client.solrj.embedded > org.eclipse.jetty.util.ssl
                 org.apache.solr.client.solrj.impl > org.eclipse.jetty.client.util
                                                     org.eclipse.jetty.client.api
                                                     org.eclipse.jetty.http
                                                     org.eclipse.jetty.util.ssl
                                                     org.eclipse.jetty.util
                                                     org.eclipse.jetty.client.http
                                                     org.eclipse.jetty.http2.client.http
                                                     org.eclipse.jetty.http2.client
                                                     org.eclipse.jetty.client
                 org.apache.solr.client.solrj.util > org.eclipse.jetty.util
                                                     org.eclipse.jetty.http
                                                     org.eclipse.jetty.client.api
```