### PR TITLE
Fix kafka-streams 3.4.0 bundle

### DIFF
--- a/kafka-streams-3.4.0/pom.xml
+++ b/kafka-streams-3.4.0/pom.xml
@@ -93,9 +93,9 @@
                             <filters>
                                 <filter>
                                     <artifact>${pkgGroupId}:${pkgArtifactId}</artifact>
-                                    <excludes>
-                                        <exclude>**/*</exclude>
-                                    </excludes>
+                                    <includes>
+                                        <include>kafka/kafka-streams-version.properties</include>
+                                    </includes>
                                 </filter>
                             </filters>
                             <promoteTransitiveDependencies>true</promoteTransitiveDependencies>


### PR DESCRIPTION
kafka-streams logs an exception at startup because a properties file is missing:
```
org.apache.kafka.streams.internals.metrics.ClientMetrics <clinit> WARN: Error while loading kafka-streams-version.properties
java.lang.NullPointerException: inStream parameter is null
at java.base/java.util.Objects.requireNonNull(Objects.java:233)
at java.base/java.util.Properties.load(Properties.java:407)
at org.apache.kafka.streams.internals.metrics.ClientMetrics.<clinit>(ClientMetrics.java:53)
at org.apache.kafka.streams.KafkaStreams.<init>(KafkaStreams.java:894)
at org.apache.kafka.streams.KafkaStreams.<init>(KafkaStreams.java:856)
at org.apache.kafka.streams.KafkaStreams.<init>(KafkaStreams.java:826)
at org.apache.kafka.streams.KafkaStreams.<init>(KafkaStreams.java:738)
```