### PR TITLE
[SM-5706] Add micrometer to spring-jms

### DIFF
--- a/spring-jms-6.1.5/pom.xml
+++ b/spring-jms-6.1.5/pom.xml
@@ -135,7 +135,9 @@
             reactor.tuple;resolution:=optional,
             reactor.rx;resolution:=optional,
             reactor.rx.action;resolution:=optional,
-            org.w3c.dom;resolution:=optional
+            org.w3c.dom;resolution:=optional,
+            io.micrometer.jakarta9.instrument.jms;resolution:=optional,
+            io.micrometer.observation
         </servicemix.osgi.import.pkg>
     </properties>
 


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/SM-5706

## Motivation

NoClassDefFoundErrors are raised when we use the SMX bundle of Spring JMS because Micrometer is not part of its import packages

## Modifications:

* Add the packages of micrometer that are used by spring-jms to the import packages 