### PR TITLE
Make Micrometer optional in Spring Security 6 config/core/web.

### DIFF
--- a/spring-security-config-6.1.9/pom.xml
+++ b/spring-security-config-6.1.9/pom.xml
@@ -51,6 +51,7 @@
         </servicemix.osgi.export.pkg>
         <servicemix.osgi.import.pkg>
             com.nimbusds.*;resolution:=optional,
+            io.micrometer.*;resolution:=optional,
             io.rsocket.plugins;resolution:=optional,
             org.reactivestreams;resolution:=optional,
 	    reactor.*;resolution:=optional,

--- a/spring-security-config-6.2.7/pom.xml
+++ b/spring-security-config-6.2.7/pom.xml
@@ -51,6 +51,7 @@
         </servicemix.osgi.export.pkg>
         <servicemix.osgi.import.pkg>
             com.nimbusds.*;resolution:=optional,
+            io.micrometer.*;resolution:=optional,
             io.rsocket.plugins;resolution:=optional,
             org.reactivestreams;resolution:=optional,
 	    reactor.*;resolution:=optional,

--- a/spring-security-config-6.3.9/pom.xml
+++ b/spring-security-config-6.3.9/pom.xml
@@ -51,6 +51,7 @@
         </servicemix.osgi.export.pkg>
         <servicemix.osgi.import.pkg>
             com.nimbusds.*;resolution:=optional,
+            io.micrometer.*;resolution:=optional,
             io.rsocket.plugins;resolution:=optional,
             org.reactivestreams;resolution:=optional,
 	    reactor.*;resolution:=optional,

--- a/spring-security-config-6.4.5/pom.xml
+++ b/spring-security-config-6.4.5/pom.xml
@@ -51,6 +51,7 @@
         </servicemix.osgi.export.pkg>
         <servicemix.osgi.import.pkg>
             com.nimbusds.*;resolution:=optional,
+            io.micrometer.*;resolution:=optional,
             io.rsocket.plugins;resolution:=optional,
             org.reactivestreams;resolution:=optional,
 	    reactor.*;resolution:=optional,

--- a/spring-security-core-6.1.9/pom.xml
+++ b/spring-security-core-6.1.9/pom.xml
@@ -50,6 +50,7 @@
             org.springframework.security
         </servicemix.osgi.export.pkg>
         <servicemix.osgi.import.pkg>
+            io.micrometer.*;resolution:=optional,
 			net.sf.ehcache;resolution:="optional",
 			org.aspectj.*;resolution:="optional",
 			org.bouncycastle.*;resolution:="optional",

--- a/spring-security-core-6.2.7/pom.xml
+++ b/spring-security-core-6.2.7/pom.xml
@@ -50,6 +50,7 @@
             org.springframework.security
         </servicemix.osgi.export.pkg>
         <servicemix.osgi.import.pkg>
+            io.micrometer.*;resolution:=optional,
 			net.sf.ehcache;resolution:="optional",
 			org.aspectj.*;resolution:="optional",
 			org.bouncycastle.*;resolution:="optional",

--- a/spring-security-core-6.3.9/pom.xml
+++ b/spring-security-core-6.3.9/pom.xml
@@ -50,6 +50,7 @@
             org.springframework.security
         </servicemix.osgi.export.pkg>
         <servicemix.osgi.import.pkg>
+            io.micrometer.*;resolution:=optional,
 			net.sf.ehcache;resolution:="optional",
 			org.aspectj.*;resolution:="optional",
 			org.bouncycastle.*;resolution:="optional",

--- a/spring-security-core-6.4.5/pom.xml
+++ b/spring-security-core-6.4.5/pom.xml
@@ -50,6 +50,7 @@
             org.springframework.security
         </servicemix.osgi.export.pkg>
         <servicemix.osgi.import.pkg>
+            io.micrometer.*;resolution:=optional,
 			net.sf.ehcache;resolution:="optional",
 			org.aspectj.*;resolution:="optional",
 			org.bouncycastle.*;resolution:="optional",

--- a/spring-security-web-6.1.9/pom.xml
+++ b/spring-security-web-6.1.9/pom.xml
@@ -54,6 +54,7 @@
 			org.reactivestreams;resolution:=optional,
 			org.springframework.jdbc*;resolution:=optional,
 			org.springframework.web.reactive*;resolution:=optional,
+			io.micrometer.*;resolution:=optional,
 			reactor.*;resolution:=optional,
 	    com.ibm.websphere*;resolution:=optional,
             *

--- a/spring-security-web-6.2.7/pom.xml
+++ b/spring-security-web-6.2.7/pom.xml
@@ -54,6 +54,7 @@
 			org.reactivestreams;resolution:=optional,
 			org.springframework.jdbc*;resolution:=optional,
 			org.springframework.web.reactive*;resolution:=optional,
+			io.micrometer.*;resolution:=optional,
 			reactor.*;resolution:=optional,
 	    com.ibm.websphere*;resolution:=optional,
             *

--- a/spring-security-web-6.3.9/pom.xml
+++ b/spring-security-web-6.3.9/pom.xml
@@ -54,6 +54,7 @@
 			org.reactivestreams;resolution:=optional,
 			org.springframework.jdbc*;resolution:=optional,
 			org.springframework.web.reactive*;resolution:=optional,
+			io.micrometer.*;resolution:=optional,
 			reactor.*;resolution:=optional,
 	    com.ibm.websphere*;resolution:=optional,
             *

--- a/spring-security-web-6.4.5/pom.xml
+++ b/spring-security-web-6.4.5/pom.xml
@@ -54,6 +54,7 @@
 			org.reactivestreams;resolution:=optional,
 			org.springframework.jdbc*;resolution:=optional,
 			org.springframework.web.reactive*;resolution:=optional,
+			io.micrometer.*;resolution:=optional,
 			reactor.*;resolution:=optional,
 	    com.ibm.websphere*;resolution:=optional,
             *


### PR DESCRIPTION
I am starting to use the Spring Security 6 bundles and found the Micrometer package imports are required, but can be optional. This change is to mark those packages as optional in the Spring Security 6 bundles.