### PR TITLE
Make webauthn4j optional in Spring Security 6 web.

### DIFF
--- a/spring-security-web-6.1.9/pom.xml
+++ b/spring-security-web-6.1.9/pom.xml
@@ -54,6 +54,7 @@
 			org.reactivestreams;resolution:=optional,
 			org.springframework.jdbc*;resolution:=optional,
 			org.springframework.web.reactive*;resolution:=optional,
+			com.webauthn4j.*;resolution:=optional,
 			reactor.*;resolution:=optional,
 	    com.ibm.websphere*;resolution:=optional,
             *

--- a/spring-security-web-6.2.7/pom.xml
+++ b/spring-security-web-6.2.7/pom.xml
@@ -54,6 +54,7 @@
 			org.reactivestreams;resolution:=optional,
 			org.springframework.jdbc*;resolution:=optional,
 			org.springframework.web.reactive*;resolution:=optional,
+			com.webauthn4j.*;resolution:=optional,
 			reactor.*;resolution:=optional,
 	    com.ibm.websphere*;resolution:=optional,
             *

--- a/spring-security-web-6.3.9/pom.xml
+++ b/spring-security-web-6.3.9/pom.xml
@@ -54,6 +54,7 @@
 			org.reactivestreams;resolution:=optional,
 			org.springframework.jdbc*;resolution:=optional,
 			org.springframework.web.reactive*;resolution:=optional,
+			com.webauthn4j.*;resolution:=optional,
 			reactor.*;resolution:=optional,
 	    com.ibm.websphere*;resolution:=optional,
             *

--- a/spring-security-web-6.4.5/pom.xml
+++ b/spring-security-web-6.4.5/pom.xml
@@ -54,6 +54,7 @@
 			org.reactivestreams;resolution:=optional,
 			org.springframework.jdbc*;resolution:=optional,
 			org.springframework.web.reactive*;resolution:=optional,
+			com.webauthn4j.*;resolution:=optional,
 			reactor.*;resolution:=optional,
 	    com.ibm.websphere*;resolution:=optional,
             *


### PR DESCRIPTION
I am starting to use the Spring Security 6 bundles and found the webauthn4j package imports are required, but can be optional. This change is to mark those packages as optional in the Spring Security 6 bundles.