### PR TITLE
Add missing reactor.adapter package import to Spring Core 6 bundles

### DIFF
--- a/spring-core-6.0.23/pom.xml
+++ b/spring-core-6.0.23/pom.xml
@@ -77,6 +77,7 @@
             org.springframework.asm.tree;version="[${pkgVersion},6.1)";resolution:=optional,
             org.springframework.asm.util;version="[${pkgVersion},6.1)";resolution:=optional,
 	    org.reactivestreams;version="[1.0,2)";resolution:=optional,
+	    reactor.adapter;version="[3.4,5)";resolution:=optional,
 	    reactor.core;version="[3.4,4)";resolution:=optional,
 	    reactor.core.publisher;version="[3.4,4)";resolution:=optional,
 	    reactor.util.concurrent;version="[3.4,4)";resolution:=optional,

--- a/spring-core-6.0.23/pom.xml
+++ b/spring-core-6.0.23/pom.xml
@@ -78,6 +78,8 @@
             org.springframework.asm.util;version="[${pkgVersion},6.1)";resolution:=optional,
 	    org.reactivestreams;version="[1.0,2)";resolution:=optional,
 	    reactor.adapter;version="[3.4,4)";resolution:=optional,
+	    reactor.blockhound;version="[3.4,5)";resolution:=optional,
+	    reactor.blockhound.integration;version="[3.4,5)";resolution:=optional,
 	    reactor.core;version="[3.4,4)";resolution:=optional,
 	    reactor.core.publisher;version="[3.4,4)";resolution:=optional,
 	    reactor.util.concurrent;version="[3.4,4)";resolution:=optional,

--- a/spring-core-6.0.23/pom.xml
+++ b/spring-core-6.0.23/pom.xml
@@ -77,7 +77,7 @@
             org.springframework.asm.tree;version="[${pkgVersion},6.1)";resolution:=optional,
             org.springframework.asm.util;version="[${pkgVersion},6.1)";resolution:=optional,
 	    org.reactivestreams;version="[1.0,2)";resolution:=optional,
-	    reactor.adapter;version="[3.4,5)";resolution:=optional,
+	    reactor.adapter;version="[3.4,4)";resolution:=optional,
 	    reactor.core;version="[3.4,4)";resolution:=optional,
 	    reactor.core.publisher;version="[3.4,4)";resolution:=optional,
 	    reactor.util.concurrent;version="[3.4,4)";resolution:=optional,

--- a/spring-core-6.1.19/pom.xml
+++ b/spring-core-6.1.19/pom.xml
@@ -77,6 +77,7 @@
             org.springframework.asm.tree;version="[${pkgVersion},6.2)";resolution:=optional,
             org.springframework.asm.util;version="[${pkgVersion},6.2)";resolution:=optional,
 	    org.reactivestreams;version="[1.0,2)";resolution:=optional,
+	    reactor.adapter;version="[3.4,5)";resolution:=optional,
 	    reactor.core;version="[3.4,4)";resolution:=optional,
 	    reactor.core.publisher;version="[3.4,4)";resolution:=optional,
 	    reactor.util.concurrent;version="[3.4,4)";resolution:=optional,

--- a/spring-core-6.1.19/pom.xml
+++ b/spring-core-6.1.19/pom.xml
@@ -77,7 +77,7 @@
             org.springframework.asm.tree;version="[${pkgVersion},6.2)";resolution:=optional,
             org.springframework.asm.util;version="[${pkgVersion},6.2)";resolution:=optional,
 	    org.reactivestreams;version="[1.0,2)";resolution:=optional,
-	    reactor.adapter;version="[3.4,5)";resolution:=optional,
+	    reactor.adapter;version="[3.4,4)";resolution:=optional,
 	    reactor.core;version="[3.4,4)";resolution:=optional,
 	    reactor.core.publisher;version="[3.4,4)";resolution:=optional,
 	    reactor.util.concurrent;version="[3.4,4)";resolution:=optional,

--- a/spring-core-6.1.19/pom.xml
+++ b/spring-core-6.1.19/pom.xml
@@ -78,6 +78,8 @@
             org.springframework.asm.util;version="[${pkgVersion},6.2)";resolution:=optional,
 	    org.reactivestreams;version="[1.0,2)";resolution:=optional,
 	    reactor.adapter;version="[3.4,4)";resolution:=optional,
+	    reactor.blockhound;version="[3.4,5)";resolution:=optional,
+	    reactor.blockhound.integration;version="[3.4,5)";resolution:=optional,
 	    reactor.core;version="[3.4,4)";resolution:=optional,
 	    reactor.core.publisher;version="[3.4,4)";resolution:=optional,
 	    reactor.util.concurrent;version="[3.4,4)";resolution:=optional,

--- a/spring-core-6.2.6/pom.xml
+++ b/spring-core-6.2.6/pom.xml
@@ -77,6 +77,7 @@
             org.springframework.asm.tree;version="[${pkgVersion},6.3)";resolution:=optional,
             org.springframework.asm.util;version="[${pkgVersion},6.3)";resolution:=optional,
 	    org.reactivestreams;version="[1.0,3)";resolution:=optional,
+	    reactor.adapter;version="[3.4,5)";resolution:=optional,
 	    reactor.core;version="[3.4,5)";resolution:=optional,
 	    reactor.core.publisher;version="[3.4,5)";resolution:=optional,
 	    reactor.util.concurrent;version="[3.4,5)";resolution:=optional,

--- a/spring-core-6.2.6/pom.xml
+++ b/spring-core-6.2.6/pom.xml
@@ -78,6 +78,8 @@
             org.springframework.asm.util;version="[${pkgVersion},6.3)";resolution:=optional,
 	    org.reactivestreams;version="[1.0,3)";resolution:=optional,
 	    reactor.adapter;version="[3.4,5)";resolution:=optional,
+	    reactor.blockhound;version="[3.4,5)";resolution:=optional,
+	    reactor.blockhound.integration;version="[3.4,5)";resolution:=optional,
 	    reactor.core;version="[3.4,5)";resolution:=optional,
 	    reactor.core.publisher;version="[3.4,5)";resolution:=optional,
 	    reactor.util.concurrent;version="[3.4,5)";resolution:=optional,


### PR DESCRIPTION
Spring Core 6 uses classes in the `reactor.adapter` package but that is not imported. This PR adds that import to the Spring Core 6 bundles.